### PR TITLE
Linting system

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-max-line-length = 88  ;consistent with black
+max-line-length = 88

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 yml2block.egg-info
 poetry.lock
+yml2block/__pycache__/

--- a/tests/duplicate_name.yml
+++ b/tests/duplicate_name.yml
@@ -1,0 +1,49 @@
+---
+metadataBlock:
+  - name: ValidExample
+    dataverseAlias:
+    displayName: Valid
+datasetField:
+  - name: Duplicate
+    title: Description
+    description: This field describes.
+    watermark:
+    fieldType: textbox
+    displayOrder:
+    displayFormat:
+    advancedSearchField: true
+    allowControlledVocabulary: false
+    allowmultiples: false
+    facetable: false
+    displayoncreate: true
+    required: true
+    parent:
+    metadatablock_id: ValidExample
+  - name: Duplicate
+    title: Answer
+    description:
+    watermark:
+    fieldType: text
+    displayOrder:
+    displayFormat:
+    advancedSearchField: true
+    allowControlledVocabulary: true
+    allowmultiples: true
+    facetable: true
+    displayoncreate: true
+    required: true
+    parent:
+    metadatablock_id: ValidExample
+controlledVocabulary:
+  - DatasetField: AnswerYes
+    Value: "Yes"
+    identifier: answer_positive
+    displayOrder:
+  - DatasetField: AnswerNo
+    Value: "No"
+    identifier: answer_negative
+    displayOrder:
+  - DatasetField: AnswerMaybeSo
+    Value: "Maybe"
+    identifier: answer_unclear
+    displayOrder:

--- a/yml2block/rules.py
+++ b/yml2block/rules.py
@@ -2,6 +2,68 @@
 """
 from collections import Counter
 
+
+# Note: The order of entries in this list defines the enforced order in the output file
+# Note: These are referred to as top-level keywords.
+permissible_keywords = ["metadataBlock", "datasetField", "controlledVocabulary"]
+
+required_keys = {
+    "metadataBlock": ["name", "displayName"],
+    "datasetField": [
+        "name",
+        "title",
+        "description",
+        "fieldType",
+        "displayOrder",
+        "advancedSearchField",
+        "allowControlledVocabulary",
+        "allowmultiples",
+        "facetable",
+        "displayoncreate",
+        "required",
+        "metadatablock_id",
+    ],
+    "controlledVocabulary": ["DatasetField", "Value"],
+}
+
+permissible_keys = {
+    "metadataBlock": ["name", "dataverseAlias", "displayName", "blockURI"],
+    "datasetField": [
+        "name",
+        "title",
+        "description",
+        "watermark",
+        "fieldType",
+        "displayOrder",
+        "displayFormat",
+        "advancedSearchField",
+        "allowControlledVocabulary",
+        "allowmultiples",
+        "facetable",
+        "displayoncreate",
+        "required",
+        "parent",
+        "metadatablock_id",
+        "termURI",
+    ],
+    "controlledVocabulary": [
+        "DatasetField",
+        "Value",
+        "identifier",
+        "displayOrder",
+    ],
+}
+
+
+def kw_order(kw):
+    """Provide the canonical sort order expected by dataverse.
+
+    Usage: `sorted(entries, key=kw_order)`
+    """
+    mdb_order = {key: i for i, key in enumerate(permissible_keywords)}
+    return mdb_order[kw]
+
+
 class LintViolation:
     def __init__(self, level, rule, message):
         self.level = level

--- a/yml2block/rules.py
+++ b/yml2block/rules.py
@@ -185,7 +185,16 @@ def required_keys_present(list_item, tsv_keyword):
     second-level list entry lint
     """
     found_keys = list_item.keys()
-    required = required_keys[tsv_keyword]
+    try:
+        required = required_keys[tsv_keyword]
+    except KeyError:
+        return [
+            LintViolation(
+                "ERROR",
+                "required_keys_present",
+                f"Cannot check entry for invalid keyword '{tsv_keyword}'. Skipping entry.",
+            )
+        ]
     # Assure all required keys are there
     if len(set(required) - set(found_keys)) == 0:
         return []
@@ -204,7 +213,17 @@ def no_invalid_keys_present(list_item, tsv_keyword):
 
     second-level list entry lint
     """
-    permissible = permissible_keys[tsv_keyword]
+    try:
+        permissible = permissible_keys[tsv_keyword]
+    except KeyError:
+        return [
+            LintViolation(
+                "ERROR",
+                "no_invalid_keys_present",
+                f"Cannot check entry for invalid keyword '{tsv_keyword}'. Skipping entry.",
+            )
+        ]
+
     violations = []
     for (key, value) in list_item.items():
         if key not in permissible:

--- a/yml2block/rules.py
+++ b/yml2block/rules.py
@@ -175,3 +175,60 @@ def top_level_keywords_complete(keywords):
                 f"Keyword list {keywords} does not contain enough entries.",
             )
         ]
+
+
+def required_keys_present(list_item, tsv_keyword):
+    """Make sure the keywords required for the current top-level item are present.
+
+    second-level list entry lint
+    """
+    found_keys = list_item.keys()
+    required = required_keys[tsv_keyword]
+    # Assure all required keys are there
+    if len(set(required) - set(found_keys)) == 0:
+        return []
+    else:
+        return [
+            LintViolation(
+                "ERROR",
+                "required_keys_present",
+                f"List of required keys {required} and found keys {found_keys} differ.",
+            )
+        ]
+
+
+def no_invalid_keys_present(list_item, tsv_keyword):
+    """Make sure no invalid keys are present.
+
+    second-level list entry lint
+    """
+    permissible = permissible_keys[tsv_keyword]
+    violations = []
+    for (key, value) in list_item.items():
+        if key not in permissible:
+            violations.append(
+                LintViolation(
+                    "ERROR",
+                    "no_invalid_keys_present",
+                    f"Invalid key {key} present in block {tsv_keyword}.",
+                )
+            )
+    return violations
+
+
+def no_substructures_present(list_item, tsv_keyword):
+    """Make sure list items do not contain dicts, tuples lists etc.
+
+    second-level list entry lint
+    """
+    violations = []
+    for (key, value) in item.items():
+        if type(value) in (dict, tuple, list):
+            violations.append(
+                LintViolation(
+                    "ERROR",
+                    "no_substructures_present",
+                    f"Key {key} in block {tsv_keyword} has a subtructure of type {type(value)}. Only strings, booleans, an numericals are allowed here.",
+                )
+            )
+    return violations

--- a/yml2block/rules.py
+++ b/yml2block/rules.py
@@ -124,7 +124,7 @@ def top_level_keywords_valid(keywords):
     if all(kw in permissible_keywords for kw in keywords):
         return []
     else:
-        [
+        return [
             LintViolation(
                 "ERROR",
                 "top_level_keywords_valid",

--- a/yml2block/rules.py
+++ b/yml2block/rules.py
@@ -77,11 +77,13 @@ class LintViolation:
         return self.__repr__()
 
 
-def unique_names(yaml_chunk):
+def unique_names(yaml_chunk, tsv_keyword):
     """Make sure that each name in the block is only used once.
 
     block content level lint
     """
+    if tsv_keyword not in ["metadataBlock", "datasetField"]:
+        return []
     names = Counter()
     for item in yaml_chunk:
         names.update([item["name"]])
@@ -222,7 +224,7 @@ def no_substructures_present(list_item, tsv_keyword):
     second-level list entry lint
     """
     violations = []
-    for (key, value) in item.items():
+    for (key, value) in list_item.items():
         if type(value) in (dict, tuple, list):
             violations.append(
                 LintViolation(

--- a/yml2block/rules.py
+++ b/yml2block/rules.py
@@ -106,4 +106,72 @@ def block_content_is_list(yaml_chunk):
     if isinstance(yaml_chunk, list):
         return []
     else:
-        return [LintViolation("ERROR", "block_content_is_list", "Entry is not a list",)]
+        return [
+            LintViolation(
+                "ERROR",
+                "block_content_is_list",
+                "Entry is not a list",
+            )
+        ]
+
+
+def top_level_keywords_valid(keywords):
+    """Make sure that the top-level keywords are spelled correctly and no additonal
+    ones are present.
+
+    top-level keyword level lint
+    """
+    if all(kw in permissible_keywords for kw in keywords):
+        return []
+    else:
+        [
+            LintViolation(
+                "ERROR",
+                "top_level_keywords_valid",
+                f"Keyword list {keywords} differs from {permissible_keywords}",
+            )
+        ]
+
+
+def top_level_keywords_unique(keywords):
+    """Make sure no keyword is specified twice.
+
+    NOTE: This is most likely also enforced by the YAML parser,
+    but adds an additional layer of security here.
+
+    top-level keyword level lint
+    """
+    unique_keys = set(keywords)
+    if len(unique_keys) == len(keywords):
+        return []
+    else:
+        return [
+            LintViolation(
+                "ERROR",
+                "top_level_keywords_unique",
+                f"Keyword list {keywords} contains duplicate keys.",
+            )
+        ]
+
+
+def top_level_keywords_complete(keywords):
+    """Make sure all required top-level keywords are present.
+
+    top-level keyword level lint
+    """
+    unique_keys = set(keywords)
+    # NOTE: This can be relaxed later to >0 and <=3 or to a membership test
+    # if we are willing to skip over empty entries.
+    # It can probably be merged with top_level_keywords_valid since only two
+    # combinations ("metadataBlock"+"datasetField"+"controlledVocabulary" and
+    # "metadataBlock"+"datasetField") are valid. But we need to verify this first.
+    if len(unique_keys) == 3:
+        return []
+    else:
+        return [
+            LintViolation(
+                "ERROR",
+                "top_level_keywords_complete",
+                f"Keyword list {keywords} does not contain enough entries.",
+            )
+        ]

--- a/yml2block/rules.py
+++ b/yml2block/rules.py
@@ -1,0 +1,47 @@
+"""This file contains lints that can be selectively applied to yaml blocks.
+"""
+from collections import Counter
+
+class LintViolation:
+    def __init__(self, level, rule, message):
+        self.level = level
+        self.rule = rule
+        self.message = message
+
+    def __repr__(self):
+        return f"{self.level} ({self.rule}): {self.message}"
+
+    def __str__(self):
+        return self.__repr__()
+
+
+def unique_names(yaml_chunk):
+    """Make sure that each name in the block is only used once.
+
+    block content level lint
+    """
+    names = Counter()
+    for item in yaml_chunk:
+        names.update([item["name"]])
+    errors = []
+    for name, count in names.items():
+        if count > 1:
+            errors.append(
+                LintViolation(
+                    "ERROR",
+                    "unique_names",
+                    f"Name {name} occurs {count} times. Names have to be unique.",
+                )
+            )
+    return errors
+
+
+def block_content_is_list(yaml_chunk):
+    """Make sure that the yaml chunk is a list.
+
+    block content level lint
+    """
+    if isinstance(yaml_chunk, list):
+        return []
+    else:
+        return [LintViolation("ERROR", "block_content_is_list", "Entry is not a list",)]

--- a/yml2block/yml2block.py
+++ b/yml2block/yml2block.py
@@ -9,67 +9,7 @@ import sys
 import click
 from yaml import load, CLoader
 
-from rules import unique_names, block_content_is_list
-
-# Note: The order of entries in this list defines the enforced order in the output file
-permissible_keywords = ["metadataBlock", "datasetField", "controlledVocabulary"]
-
-
-def kw_order(kw):
-    """Provide the canonical sort order expected by dataverse.
-
-    Usage: `sorted(entries, key=kw_order)`
-    """
-    mdb_order = {key: i for i, key in enumerate(permissible_keywords)}
-    return mdb_order[kw]
-
-
-required_keys = {
-    "metadataBlock": ["name", "displayName"],
-    "datasetField": [
-        "name",
-        "title",
-        "description",
-        "fieldType",
-        "displayOrder",
-        "advancedSearchField",
-        "allowControlledVocabulary",
-        "allowmultiples",
-        "facetable",
-        "displayoncreate",
-        "required",
-        "metadatablock_id",
-    ],
-    "controlledVocabulary": ["DatasetField", "Value"],
-}
-
-permissible_keys = {
-    "metadataBlock": ["name", "dataverseAlias", "displayName", "blockURI"],
-    "datasetField": [
-        "name",
-        "title",
-        "description",
-        "watermark",
-        "fieldType",
-        "displayOrder",
-        "displayFormat",
-        "advancedSearchField",
-        "allowControlledVocabulary",
-        "allowmultiples",
-        "facetable",
-        "displayoncreate",
-        "required",
-        "parent",
-        "metadatablock_id",
-        "termURI",
-    ],
-    "controlledVocabulary": [
-        "DatasetField",
-        "Value",
-        "identifier",
-        "displayOrder",
-    ],
-}
+import rules
 
 
 def validate_keywords(keywords, verbose):
@@ -102,19 +42,19 @@ def validate_entry(yaml_chunk, tsv_keyword, verbose):
         print(f"Validating entries for {tsv_keyword}:", end=" ")
 
     violations = []
-    for lint in (block_content_is_list,):
+    for lint in (rules.block_content_is_list,):
         violations.extend(lint(yaml_chunk))
 
     # Get these litsts once to prevent repeated dictionary accesses
-    permissible = permissible_keys[tsv_keyword]
-    required = required_keys[tsv_keyword]
+    permissible = rules.permissible_keys[tsv_keyword]
+    required = rules.required_keys[tsv_keyword]
 
     longest_row = 0
 
     if tsv_keyword in ["metadataBlock", "datasetField"]:
-        if v := unique_names(yaml_chunk):
+        if v := rules.unique_names(yaml_chunk):
             violations.extend(v)
-    
+
     for item in yaml_chunk:
         found_keys = item.keys()
         # Assure all required keys are there

--- a/yml2block/yml2block.py
+++ b/yml2block/yml2block.py
@@ -62,7 +62,13 @@ def validate_entry(yaml_chunk, tsv_keyword, verbose):
         permissible = rules.permissible_keys[tsv_keyword]
         required = rules.required_keys[tsv_keyword]
     except KeyError:
-        return 0, [rules.LintViolation("ERROR", "entry_invalid_keyword", f"Cannot check entry for keyword '{tsv_keyword}'. Skipping entry.")]
+        return 0, [
+            rules.LintViolation(
+                "ERROR",
+                "entry_invalid_keyword",
+                f"Cannot check entry for keyword '{tsv_keyword}'. Skipping entry.",
+            )
+        ]
 
     longest_row = 0
 
@@ -147,7 +153,9 @@ def write_metadata_block(yml_metadata, output_path, longest_line, verbose):
             block_header_fragments = [block_name] + block_headers
             # Pad header to longest column
             if len(block_header_fragments) < longest_line:
-                block_header_fragments.extend([""] * (longest_line - len(block_header_fragments)))
+                block_header_fragments.extend(
+                    [""] * (longest_line - len(block_header_fragments))
+                )
             block_header = "\t".join(block_header_fragments)
 
             print(block_header, file=out_file)

--- a/yml2block/yml2block.py
+++ b/yml2block/yml2block.py
@@ -30,8 +30,7 @@ def validate_keywords(keywords, verbose):
         if verbose >= 2:
             print(f"Running lint: {lint.__name__}")
 
-        if lint_results := lint(keywords):
-            violations.extend(lint_results)
+        violations.extend(lint(keywords))
 
     if verbose and len(violations) == 0:
         print("SUCCESS!" if verbose == 1 else "SUCCESS!\n")
@@ -55,7 +54,8 @@ def validate_entry(yaml_chunk, tsv_keyword, verbose):
     for lint in (rules.block_content_is_list,):
         violations.extend(lint(yaml_chunk))
 
-    # Get these litsts once to prevent repeated dictionary accesses
+    # Get these lists once to prevent repeated dictionary accesses
+    print(rules.permissible_keys)
     permissible = rules.permissible_keys[tsv_keyword]
     required = rules.required_keys[tsv_keyword]
 

--- a/yml2block/yml2block.py
+++ b/yml2block/yml2block.py
@@ -91,7 +91,7 @@ def validate_entry(yaml_chunk, tsv_keyword, verbose):
     return longest_row
 
 
-def write_metadata_block(yml_metadata, output_path, verbose):
+def write_metadata_block(yml_metadata, output_path, longest_line, verbose):
     """Write a validated nested dictionary of yml_metadata into
     a dataverse tsv metadata block file.
     """
@@ -134,9 +134,18 @@ def write_metadata_block(yml_metadata, output_path, verbose):
                     else:
                         # This should never happend
                         print(f"Invalid entry '{value}'", file=sys.stderr)
-                # TODO: Pad new lines to longest column
+
+                # Pad new lines to longest column
+                if len(new_line) < longest_line:
+                    new_line.extend([""] * (longest_line - len(new_line)))
+
                 block_lines.append("\t".join(new_line))
-            block_header = "\t".join([block_name] + block_headers)
+
+            block_header_fragments = [block_name] + block_headers
+            # Pad header to longest column
+            if len(block_header_fragments) < longest_line:
+                block_header_fragments.extend([""] * (longest_line - len(block_header_fragments)))
+            block_header = "\t".join(block_header_fragments)
 
             print(block_header, file=out_file)
             print("\n".join(block_lines), file=out_file)

--- a/yml2block/yml2block.py
+++ b/yml2block/yml2block.py
@@ -67,7 +67,9 @@ def validate_entry(yaml_chunk, tsv_keyword, verbose):
             assert not isinstance(value, dict), "Nested dictionaries are not allowed"
 
         # Compute the highest number of columns in the block
-        row_length = len(item.keys()) if tsv_keyword == "metadataBlock" else len(item.keys()) + 1
+        row_length = (
+            len(item.keys()) if tsv_keyword == "metadataBlock" else len(item.keys()) + 1
+        )
         longest_row = max(longest_row, row_length)
 
     if verbose and len(violations) == 0:

--- a/yml2block/yml2block.py
+++ b/yml2block/yml2block.py
@@ -16,19 +16,23 @@ def validate_keywords(keywords, verbose):
     """Assure that the top-level keywords of the YAML file are well-behaved.
 
     Fail with an assertion if they do not comply."""
-    if verbose:
+    if verbose == 1:
         print("Validating top-level keywords:", end=" ")
-    # Prevent typos and additional entries
+    elif verbose >= 2:
+        print(f"Validating top-level keywords:\n{keywords}")
+
     violations = []
     for lint in [
         rules.top_level_keywords_valid,
         rules.top_level_keywords_unique,
         rules.top_level_keywords_complete,
     ]:
+        if verbose >= 2:
+            print(f"Running lint: {lint.__name__}")
         violations.extend(lint(keywords))
 
     if verbose and len(violations) == 0:
-        print("SUCCESS!")
+        print("SUCCESS!" if verbose == 1 else "SUCCESS!\n")
     if violations:
         print("FAILURE! Detected violations:")
         print("\n".join([str(v) for v in violations]))
@@ -40,8 +44,10 @@ def validate_entry(yaml_chunk, tsv_keyword, verbose):
     Check that all required keys are there.
     Fail with an assertion if a violation is detected.
     """
-    if verbose:
+    if verbose == 1:
         print(f"Validating entries for {tsv_keyword}:", end=" ")
+    elif verbose >= 2:
+        print(f"Validating entries for {tsv_keyword}:\n{yaml_chunk}")
 
     violations = []
     for lint in (rules.block_content_is_list,):
@@ -73,7 +79,7 @@ def validate_entry(yaml_chunk, tsv_keyword, verbose):
         longest_row = max(longest_row, row_length)
 
     if verbose and len(violations) == 0:
-        print("SUCCESS!")
+        print("SUCCESS!" if verbose == 1 else "SUCCESS!\n")
     if violations:
         print("FAILURE! Detected violations:")
         print("\n".join([str(v) for v in violations]))
@@ -148,11 +154,12 @@ def validate_yaml(data, verbose):
 
 @click.command()
 @click.argument("file_path")
-@click.option("--verbose", "-v", is_flag=True, help="Print performed checks to stdout.")
+@click.option("--verbose", "-v", count=True, help="Print performed checks to stdout.")
 @click.option(
     "--outfile", "-o", nargs=1, help="Path to where the output file will be written."
 )
 def main(file_path, verbose, outfile):
+
     if outfile is None:
         path, _ext = os.path.splitext(file_path)
         outfile = f"{path}.tsv"

--- a/yml2block/yml2block.py
+++ b/yml2block/yml2block.py
@@ -146,7 +146,7 @@ def validate_yaml(data, verbose):
         violations.extend(block_violations)
         longest_row = max(longest_row, block_row_max)
     if verbose:
-        print("\nAll Checks passed!\n\n")
+        print("\nAll block-level checks passed!\n\n")
     return violations, longest_row
 
 
@@ -173,8 +173,11 @@ def main(file_path, verbose, outfile, check):
     if verbose >= 2:
         print(f"Longest row has {longest_row} columns")
 
-    if len(violations) == 0 and not check:
-        write_metadata_block(data, outfile, verbose)
+    if len(violations) == 0:
+        if verbose:
+            print("All checks passed!")
+        if not check:
+            write_metadata_block(data, outfile, verbose)
     else:
         print(f"A total of {len(violations)} lint(s) failed.")
         sys.exit(1)

--- a/yml2block/yml2block.py
+++ b/yml2block/yml2block.py
@@ -50,12 +50,12 @@ def validate_entry(yaml_chunk, tsv_keyword, verbose):
         print(f"Validating entries for {tsv_keyword}:\n{yaml_chunk}")
 
     violations = []
-    for lint in (rules.block_content_is_list, ):
+    for lint in (rules.block_content_is_list,):
         violations.extend(lint(yaml_chunk))
 
     longest_row = 0
 
-    for lint in (rules.unique_names, ):
+    for lint in (rules.unique_names,):
         violations.extend(lint(yaml_chunk, tsv_keyword))
 
     for item in yaml_chunk:
@@ -156,7 +156,11 @@ def validate_yaml(data, verbose):
 @click.option(
     "--outfile", "-o", nargs=1, help="Path to where the output file will be written."
 )
-@click.option("--check", is_flag=True, help="Only check the yaml file and do not write any output.")
+@click.option(
+    "--check",
+    is_flag=True,
+    help="Only check the yaml file and do not write any output.",
+)
 def main(file_path, verbose, outfile, check):
 
     if outfile is None:
@@ -181,6 +185,7 @@ def main(file_path, verbose, outfile, check):
     else:
         print(f"A total of {len(violations)} lint(s) failed.")
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/yml2block/yml2block.py
+++ b/yml2block/yml2block.py
@@ -55,9 +55,11 @@ def validate_entry(yaml_chunk, tsv_keyword, verbose):
         violations.extend(lint(yaml_chunk))
 
     # Get these lists once to prevent repeated dictionary accesses
-    print(rules.permissible_keys)
-    permissible = rules.permissible_keys[tsv_keyword]
-    required = rules.required_keys[tsv_keyword]
+    try:
+        permissible = rules.permissible_keys[tsv_keyword]
+        required = rules.required_keys[tsv_keyword]
+    except KeyError:
+        return 0, [rules.LintViolation("ERROR", "entry_invalid_keyword", f"Cannot check entry for keyword '{tsv_keyword}'. Skipping entry.")]
 
     longest_row = 0
 

--- a/yml2block/yml2block.py
+++ b/yml2block/yml2block.py
@@ -19,17 +19,19 @@ def validate_keywords(keywords, verbose):
     if verbose:
         print("Validating top-level keywords:", end=" ")
     # Prevent typos and additional entries
-    assert all(kw in permissible_keywords for kw in keywords), "Invalid key"
+    violations = []
+    for lint in [
+        rules.top_level_keywords_valid,
+        rules.top_level_keywords_unique,
+        rules.top_level_keywords_complete,
+    ]:
+        violations.extend(lint(keywords))
 
-    unique_keys = set(keywords)
-    # Prevent duplicate entries
-    assert len(unique_keys) == len(keywords), "Duplicate key"
-    # Assure all entries are set
-    # NOTE: This can be relaxed later to >0 and <=3 if we
-    # are willing to skip over empty entries
-    assert len(unique_keys) == 3, "Missing key"
-    if verbose:
+    if verbose and len(violations) == 0:
         print("SUCCESS!")
+    if violations:
+        print("FAILURE! Detected violations:")
+        print("\n".join([str(v) for v in violations]))
 
 
 def validate_entry(yaml_chunk, tsv_keyword, verbose):

--- a/yml2block/yml2block.py
+++ b/yml2block/yml2block.py
@@ -29,7 +29,9 @@ def validate_keywords(keywords, verbose):
     ]:
         if verbose >= 2:
             print(f"Running lint: {lint.__name__}")
-        violations.extend(lint(keywords))
+
+        if lint_results := lint(keywords):
+            violations.extend(lint_results)
 
     if verbose and len(violations) == 0:
         print("SUCCESS!" if verbose == 1 else "SUCCESS!\n")

--- a/yml2block/yml2block.py
+++ b/yml2block/yml2block.py
@@ -57,19 +57,6 @@ def validate_entry(yaml_chunk, tsv_keyword, verbose):
     for lint in (rules.block_content_is_list,):
         violations.extend(lint(yaml_chunk))
 
-    # Get these lists once to prevent repeated dictionary accesses
-    try:
-        permissible = rules.permissible_keys[tsv_keyword]
-        required = rules.required_keys[tsv_keyword]
-    except KeyError:
-        return 0, [
-            rules.LintViolation(
-                "ERROR",
-                "entry_invalid_keyword",
-                f"Cannot check entry for keyword '{tsv_keyword}'. Skipping entry.",
-            )
-        ]
-
     longest_row = 0
 
     for lint in (rules.unique_names,):
@@ -207,7 +194,7 @@ def main(file_path, verbose, outfile, check):
         if not check:
             write_metadata_block(data, outfile, longest_row, verbose)
     else:
-        print(f"A total of {len(violations)} lint(s) failed.")
+        print(f"A total of {len(lint_violations)} lint(s) failed.")
         for violation in lint_violations:
             print(violation)
         print("Errors detected. Could not convert to TSV.")

--- a/yml2block/yml2block.py
+++ b/yml2block/yml2block.py
@@ -50,14 +50,13 @@ def validate_entry(yaml_chunk, tsv_keyword, verbose):
         print(f"Validating entries for {tsv_keyword}:\n{yaml_chunk}")
 
     violations = []
-    for lint in (rules.block_content_is_list,):
+    for lint in (rules.block_content_is_list, ):
         violations.extend(lint(yaml_chunk))
 
     longest_row = 0
 
-    if tsv_keyword in ["metadataBlock", "datasetField"]:
-        if v := rules.unique_names(yaml_chunk):
-            violations.extend(v)
+    for lint in (rules.unique_names, ):
+        violations.extend(lint(yaml_chunk, tsv_keyword))
 
     for item in yaml_chunk:
         for lint in (

--- a/yml2block/yml2block.py
+++ b/yml2block/yml2block.py
@@ -156,7 +156,8 @@ def validate_yaml(data, verbose):
 @click.option(
     "--outfile", "-o", nargs=1, help="Path to where the output file will be written."
 )
-def main(file_path, verbose, outfile):
+@click.option("--check", is_flag=True, help="Only check the yaml file and do not write any output.")
+def main(file_path, verbose, outfile, check):
 
     if outfile is None:
         path, _ext = os.path.splitext(file_path)
@@ -172,7 +173,7 @@ def main(file_path, verbose, outfile):
     if verbose >= 2:
         print(f"Longest row has {longest_row} columns")
 
-    if len(violations) == 0:
+    if len(violations) == 0 and not check:
         write_metadata_block(data, outfile, verbose)
     else:
         print(f"A total of {len(violations)} lint(s) failed.")


### PR DESCRIPTION
This PR adds a modular linting system. Instead of immediately failing after one violated assertion, now lint violations are collected in a list, passed up to the main function and handled there. This architecture can later be extended to only use lints that chosen by the user, or to skip specific lints.

Lint violations are now modeled as a class that contains an error level (currently "ERROR" for all lints), the name of the linting rule that detected the violation, and a custom error message. This is a first and very simple solution that might be extended with a more sophisticated system later. Using a class based on the Python error/ exception types could be an interesting thought (as this would allow us to use try/except structures).

Additionally, this PR adds some convenience features:
- The `--check` flag allows to only lint a file, but not create any output files. 
- Support for different verbosity levels
- The program now fails with an error code, if any errors are detected.