### PR TITLE
Add TSV file input

### DIFF
--- a/.github/workflows/tests_and_lints.yml
+++ b/.github/workflows/tests_and_lints.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Test that direct execution works
         run: |
           poetry run python yml2block --help
+      - name: Run unit tests
+        run: |
+          poetry run pytest -v tests/unit_tests.py
       - name: Run integration tests
         run: |
           poetry run pytest -v tests/integration_tests.py

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ you can also call `yml2block` directly:
 The path to the input file containing the metadata schema in YAML format
 is given as the positional parameter.
 
+If a path to a tsv file is given as the positional parameter, this file
+will only be linted as if the `--check` parameter was passed.
+No output is written in this case.
+
 ### Output
 By default, the output will be written to the same path as the input file,
 replacing the `.yml`/ `.yaml` suffix with `.tsv`.

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -44,3 +44,11 @@ def test_typo_in_key_key_detected():
         yml2block.__main__.main, ["tests/invalid/typo_in_key.yml", "--check"]
     )
     assert result.exit_code == 1, result.output
+
+def test_wrong_extensions_fail():
+    """Ensure that files that do not end in tsv, csv, yml or yaml fail."""
+    runner = CliRunner()
+    result = runner.invoke(
+        yml2block.__main__.main, ["tests/invalid/minimal_example.xlsx", "--check"]
+    )
+    assert result.exit_code == 1, result.output

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -45,6 +45,7 @@ def test_typo_in_key_key_detected():
     )
     assert result.exit_code == 1, result.output
 
+
 def test_wrong_extensions_fail():
     """Ensure that files that do not end in tsv, csv, yml or yaml fail."""
     runner = CliRunner()

--- a/tests/invalid/minimal_example.xlsx
+++ b/tests/invalid/minimal_example.xlsx
@@ -1,0 +1,49 @@
+---
+metadataBlock:
+  - name: ValidExample
+    dataverseAlias:
+    displayName: Valid
+datasetField:
+  - name: Description
+    title: Description
+    description: This field describes.
+    watermark:
+    fieldType: textbox
+    displayOrder:
+    displayFormat:
+    advancedSearchField: true
+    allowControlledVocabulary: false
+    allowmultiples: false
+    facetable: false
+    displayoncreate: true
+    required: true
+    parent:
+    metadatablock_id: ValidExample
+  - name: Answer
+    title: Answer
+    description:
+    watermark:
+    fieldType: text
+    displayOrder:
+    displayFormat:
+    advancedSearchField: true
+    allowControlledVocabulary: true
+    allowmultiples: true
+    facetable: true
+    displayoncreate: true
+    required: true
+    parent:
+    metadatablock_id: ValidExample
+controlledVocabulary:
+  - DatasetField: AnswerYes
+    Value: "Yes"
+    identifier: answer_positive
+    displayOrder:
+  - DatasetField: AnswerNo
+    Value: "No"
+    identifier: answer_negative
+    displayOrder:
+  - DatasetField: AnswerMaybeSo
+    Value: "Maybe"
+    identifier: answer_unclear
+    displayOrder:

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1,0 +1,118 @@
+from yml2block.__main__ import guess_input_type
+
+def test_input_guessing_valid_tsv():
+    """Are valid paths to TSV files handled correctly?
+    """
+    valid_tsv_paths = [
+        "foo.tsv",
+        "foo.Tsv",
+        "foo.TSV",
+        "~/foo.tsv",
+        "~/foo.Tsv",
+        "~/foo.TSV",
+        "../foo.tsv",
+        "../foo.Tsv",
+        "../foo.TSV",
+        "bar/foo.tsv",
+        "bar/foo.Tsv",
+        "bar/foo.TSV",
+        "/bar/foo.tsv",
+        "/bar/foo.Tsv",
+        "/bar/foo.TSV",
+    ]
+    for path in valid_tsv_paths:
+        guessed_type, violations = guess_input_type(path)
+        assert len(violations) == 0
+        assert guessed_type == "tsv"
+
+def test_input_guessing_valid_csv():
+    """Are valid paths to CSV files handled correctly?
+    """
+    valid_csv_paths = [
+        "foo.csv",
+        "foo.Csv",
+        "foo.CSV",
+        "~/foo.csv",
+        "~/foo.Csv",
+        "~/foo.CSV",
+        "../foo.csv",
+        "../foo.Csv",
+        "../foo.CSV",
+        "bar/foo.csv",
+        "bar/foo.Csv",
+        "bar/foo.CSV",
+        "/bar/foo.csv",
+        "/bar/foo.Csv",
+        "/bar/foo.CSV",
+    ]
+    for path in valid_csv_paths:
+        guessed_type, violations = guess_input_type(path)
+        assert len(violations) == 1
+        assert violations[0].level == "WARNING"
+        assert guessed_type == "csv"
+
+def test_input_guessing_valid_yaml():
+    """Are valid paths to YML and YAML files handled correctly?
+    """
+    valid_yml_paths = [
+        "foo.yml",
+        "foo.Yml",
+        "foo.YML",
+        "~/foo.yml",
+        "~/foo.Yml",
+        "~/foo.YML",
+        "../foo.yml",
+        "../foo.Yml",
+        "../foo.YML",
+        "bar/foo.yml",
+        "bar/foo.Yml",
+        "bar/foo.YML",
+        "/bar/foo.yml",
+        "/bar/foo.Yml",
+        "/bar/foo.YML",
+        "foo.yaml",
+        "foo.Yaml",
+        "foo.YAML",
+        "~/foo.yaml",
+        "~/foo.Yaml",
+        "~/foo.YAML",
+        "../foo.yaml",
+        "../foo.Yaml",
+        "../foo.YAML",
+        "bar/foo.yaml",
+        "bar/foo.Yaml",
+        "bar/foo.YAML",
+        "/bar/foo.yaml",
+        "/bar/foo.Yaml",
+        "/bar/foo.YAML",
+    ]
+    for path in valid_yml_paths:
+        guessed_type, violations = guess_input_type(path)
+        assert len(violations) == 0
+        assert guessed_type == "yaml"
+
+def test_input_guessing_invalid_extension():
+    """Are invalid extensions handled correctly?
+    """
+    invalid_extension_paths = [
+        "foo.yam",
+        "foo.xls",
+        "foo.xlsx",
+        "~/foo.dat",
+        "~/foo.txt",
+        "~/foo.gz",
+        "../foo.tar.gz",
+        "../foo.zip",
+        "../foo.bar",
+        "bar/foo.baz",
+        "bar/foo.foo",
+        "bar/foo.sdf",
+        "/bar/foo.äöü",
+        "/bar/foo.123",
+        "/bar/foo.foo",        
+    ]
+    for path in invalid_extension_paths:
+        guessed_type, violations = guess_input_type(path)
+        assert len(violations) == 1
+        assert violations[0].level == "ERROR"
+        assert guessed_type == False

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1,8 +1,8 @@
 from yml2block.__main__ import guess_input_type
 
+
 def test_input_guessing_valid_tsv():
-    """Are valid paths to TSV files handled correctly?
-    """
+    """Are valid paths to TSV files handled correctly?"""
     valid_tsv_paths = [
         "foo.tsv",
         "foo.Tsv",
@@ -25,9 +25,9 @@ def test_input_guessing_valid_tsv():
         assert len(violations) == 0
         assert guessed_type == "tsv"
 
+
 def test_input_guessing_valid_csv():
-    """Are valid paths to CSV files handled correctly?
-    """
+    """Are valid paths to CSV files handled correctly?"""
     valid_csv_paths = [
         "foo.csv",
         "foo.Csv",
@@ -51,9 +51,9 @@ def test_input_guessing_valid_csv():
         assert violations[0].level == "WARNING"
         assert guessed_type == "csv"
 
+
 def test_input_guessing_valid_yaml():
-    """Are valid paths to YML and YAML files handled correctly?
-    """
+    """Are valid paths to YML and YAML files handled correctly?"""
     valid_yml_paths = [
         "foo.yml",
         "foo.Yml",
@@ -91,9 +91,9 @@ def test_input_guessing_valid_yaml():
         assert len(violations) == 0
         assert guessed_type == "yaml"
 
+
 def test_input_guessing_invalid_extension():
-    """Are invalid extensions handled correctly?
-    """
+    """Are invalid extensions handled correctly?"""
     invalid_extension_paths = [
         "foo.yam",
         "foo.xls",
@@ -109,7 +109,7 @@ def test_input_guessing_invalid_extension():
         "bar/foo.sdf",
         "/bar/foo.äöü",
         "/bar/foo.123",
-        "/bar/foo.foo",        
+        "/bar/foo.foo",
     ]
     for path in invalid_extension_paths:
         guessed_type, violations = guess_input_type(path)

--- a/yml2block/__init__.py
+++ b/yml2block/__init__.py
@@ -2,3 +2,4 @@ from . import __main__
 from . import rules
 from . import validation
 from . import output
+from . import tsv_input

--- a/yml2block/__init__.py
+++ b/yml2block/__init__.py
@@ -3,3 +3,4 @@ from . import rules
 from . import validation
 from . import output
 from . import tsv_input
+from . import yaml_input

--- a/yml2block/__main__.py
+++ b/yml2block/__main__.py
@@ -78,7 +78,9 @@ def main(file_path, verbose, outfile, check):
             yaml = YAML(typ="safe")
             try:
                 data = yaml.load(yml_file)
-                longest_row, file_lint_violations = validation.validate_yaml(data, verbose)
+                longest_row, file_lint_violations = validation.validate_yaml(
+                    data, verbose
+                )
             except DuplicateKeyError as dke:
                 longest_row = 0
                 file_lint_violations = [
@@ -88,10 +90,13 @@ def main(file_path, verbose, outfile, check):
                         dke.problem,
                     )
                 ]
-    else input_type in ("tsv", "csv"):
+    elif input_type in ("tsv", "csv"):
         data, tsv_parsing_violations = tsv_input.read_tsv(file_path)
         lint_violations.extend(tsv_parsing_violations)
         longest_row, file_lint_violations = validation.validate_yaml(data, verbose)
+    else:
+        file_lint_violations = []
+        longest_row = 0
 
     lint_violations.extend(file_lint_violations)
 

--- a/yml2block/__main__.py
+++ b/yml2block/__main__.py
@@ -72,9 +72,9 @@ def main(file_path, verbose, outfile, check):
     lint_violations.extend(file_ext_violations)
 
     if input_type == "yaml":
-        data, yaml_parsing_violations = yaml_input.read_yaml(file_path)
-        lint_violations.extend(yaml_parsing_violations)
-        longest_row, file_lint_violations = validation.validate_yaml(data, verbose)
+        data, longest_row, file_lint_violations = yaml_input.read_yaml(
+            file_path, verbose
+        )
     elif input_type in ("tsv", "csv"):
         data, tsv_parsing_violations = tsv_input.read_tsv(file_path)
         lint_violations.extend(tsv_parsing_violations)

--- a/yml2block/__main__.py
+++ b/yml2block/__main__.py
@@ -20,20 +20,20 @@ def guess_input_type(input_path):
     """Guess the input type from the file name."""
     _, ext = os.path.splitext(input_path)
     ext = ext.lower()
-    if ext == "tsv":
+    if ext == ".tsv":
         return ("tsv", [])
-    elif ext == "csv":
+    elif ext == ".csv":
         return (
             "csv",
             [
                 rules.LintViolation(
                     "WARNING",
                     "guess_input_type",
-                    f"Invalid file extension '{csv}'. Will be treated as tsv. Currently non-tab separators are not supported.",
+                    f"Invalid file extension '{ext}'. Will be treated as tsv. Currently non-tab separators are not supported.",
                 )
             ],
         )
-    elif ext in ("yml", "yaml"):
+    elif ext in (".yml", ".yaml"):
         return ("yaml", [])
     else:
         return (
@@ -42,7 +42,7 @@ def guess_input_type(input_path):
                 rules.LintViolation(
                     "ERROR",
                     "guess_input_type",
-                    f"Invalid file extension '{ext}'. Only tsv and yaml files are supported.",
+                    f"Invalid file extension '{ext}'. Only .tsv and .yaml/.yml files are supported.",
                 )
             ],
         )

--- a/yml2block/__main__.py
+++ b/yml2block/__main__.py
@@ -103,7 +103,7 @@ def main(file_path, verbose, outfile, check):
     if len(lint_violations) == 0:
         if verbose:
             print("\nAll Checks passed!\n\n")
-        if not check:
+        if (not check) and (input_type == "yaml"):
             output.write_metadata_block(data, outfile, longest_row, verbose)
     else:
         print(f"A total of {len(lint_violations)} lint(s) failed.")

--- a/yml2block/__main__.py
+++ b/yml2block/__main__.py
@@ -59,7 +59,6 @@ def guess_input_type(input_path):
     help="Only check the yaml file and do not write any output.",
 )
 def main(file_path, verbose, outfile, check):
-
     if outfile is None:
         path, _ext = os.path.splitext(file_path)
         outfile = f"{path}.tsv"

--- a/yml2block/rules.py
+++ b/yml2block/rules.py
@@ -225,7 +225,7 @@ def no_invalid_keys_present(list_item, tsv_keyword):
         ]
 
     violations = []
-    for (key, value) in list_item.items():
+    for key, value in list_item.items():
         if key not in permissible:
             violations.append(
                 LintViolation(
@@ -243,7 +243,7 @@ def no_substructures_present(list_item, tsv_keyword):
     second-level list entry lint
     """
     violations = []
-    for (key, value) in list_item.items():
+    for key, value in list_item.items():
         if type(value) in (dict, tuple, list):
             violations.append(
                 LintViolation(

--- a/yml2block/tsv_input.py
+++ b/yml2block/tsv_input.py
@@ -1,3 +1,8 @@
+"""This module provides a parser to convert a Dataverse TSV file into the same
+dictionary-based representation used for YAML input.
+"""
+
+
 def _trim_to_header(line, length):
     """Trim leading and trailing tabs from a tsv chunk to given nr of columns.
 

--- a/yml2block/tsv_input.py
+++ b/yml2block/tsv_input.py
@@ -12,6 +12,7 @@ def _identify_break_points(full_file):
     """Identify where to split the metadata block into its three subsections"""
     violations = []
 
+    # Split slong lines starting with '#'
     break_points = [i for i, l in enumerate(full_file) if l.startswith("#")]
     if len(break_points) == 3:
         split_blocks = (
@@ -38,7 +39,7 @@ def _identify_break_points(full_file):
 
 
 def read_tsv(tsv_path):
-    """Read in a Dataverse TSV metadata block file."""
+    """Read in a Dataverse TSV metadata block file and convert it into a python diytionary structure."""
     violations = []
     data = dict()
 
@@ -96,12 +97,5 @@ def read_tsv(tsv_path):
             data[toplevel_key] = []
 
         data[toplevel_key].append(row_as_dict)
-
-    # Run top_level_keywords_valid here to make sure that the generated
-    # data structure behaves as expected down the line
-
-    # create dict that maps keywords to lists of dicts
-    # Validate that nothing is in the leftover fields
-    # Alert about whitespaces
 
     return data, violations

--- a/yml2block/tsv_input.py
+++ b/yml2block/tsv_input.py
@@ -3,49 +3,101 @@ dictionary-based representation used for YAML input.
 """
 import csv
 import io
+import itertools
+
+from yml2block.rules import LintViolation
+
+# def _trim_to_header(line, length):
+#     """Trim leading and trailing tabs from a tsv chunk to given nr of columns.
+
+#     The three parts of a Dataverse TSV file are themselves valid tsv.
+#     However, they all start with leadingall lines but the header start
+#     with a leading empty column and the shorter sections contain several
+#     empty trailing columns.
+#     """
+#     _leading_tab, *fields = line.strip("\n").split("\t")
+#     return "\t".join(fields[:length])
 
 
-def _trim_to_header(line, length):
-    """Trim leading and trailing tabs from a tsv chunk to given nr of columns.
+def _identify_break_points(full_file):
+    """Identify where to split the metadata block into its three subsections"""
+    violations = []
 
-    The three parts of a Dataverse TSV file are themselves valid tsv.
-    However, they all start with leadingall lines but the header start
-    with a leading empty column and the shorter sections contain several
-    empty trailing columns.
-    """
-    _leading_tab, *fields = line.strip("\n").split("\t")
-    return "\t".join(fields[:length])
+    break_points = [i for i, l in enumerate(full_file) if l.startswith("#")]
+    if len(break_points) == 3:
+        split_blocks = (
+            full_file[break_points[0] : break_points[1]],
+            full_file[break_points[1] : break_points[2]],
+            full_file[break_points[2] :],
+        )
+    elif len(break_points) == 2:
+        split_blocks = (
+            full_file[break_points[0] : break_points[1]],
+            full_file[break_points[1] :],
+            None,
+        )
+    else:
+        split_block = full_file
+        violations.append(
+            LintViolation(
+                "WARNING",
+                "identify_break_points",
+                "Unable to split TSV file into blocks. Check tsv file formatting.",
+            )
+        )
+    return split_blocks, violations
 
 
 def read_tsv(tsv_path):
-    with open(tsv_path, "r") as raw_file:
-        mdb_lines = raw_file.readlines()
+    violations = []
 
-    full_file = open("computational_workflow.tsv", "r").readlines()
-    break_points = [i for i, l in enumerate(full_file) if l.startswith("#")]
-    split_blocks = (
-        full_file[break_points[0] : break_points[1]],
-        full_file[break_points[1] : break_points[2]],
-        full_file[break_points[2] :],
-    )
+    with open(tsv_path, "r") as raw_file:
+        full_file = raw_file.readlines()
+
+    split_blocks, break_point_violations = _identify_break_points(full_file)
+    violations.extend(break_point_violations)
 
     def _parse(block):
         """Parse a CSV block into a dictionary."""
+        if block is None:
+            return []
         # Wrap the joined lines in a StringIO buffer so it behaves
         # like a file an can be read by the csv DictReader
         joined = io.StringIO("\n".join(block))
         return csv.DictReader(joined, delimiter="\t")
 
     md_fields, ds_fields, vocab_fields = [_parse(block) for block in split_blocks]
+    data = dict()
 
     def print_dict(d):
         for r in d:
             print(r)
 
-    print_dict(md_fields)
-    print_dict(ds_fields)
-    print_dict(vocab_fields)
+    # print_dict(md_fields)
+    # print_dict(ds_fields)
+    # print_dict(vocab_fields)
 
+    for row in itertools.chain(*(md_fields, ds_fields, vocab_fields)):
+        toplevel_key_with_hash = [
+            entry for entry in row.keys() if entry is not None and entry.startswith("#")
+        ][0]
+        toplevel_key = toplevel_key_with_hash.lstrip("#")
+        row_as_dict = dict()
+
+        for key, value in row.items():
+            if key is None:
+                violations.append(
+                    LintViolation("ERROR", "read_tsv", "Entry in headerless column")
+                )
+            elif key is toplevel_key_with_hash:
+                continue
+            else:
+                row_as_dict[key] = value
+        if not (toplevel_key in data.keys()):
+            data[toplevel_key] = []
+        data[toplevel_key].append(row_as_dict)
+
+    print(data)
     # clip off keyword
 
     # Run top_level_keywords_valid here to make sure that the generated
@@ -54,3 +106,5 @@ def read_tsv(tsv_path):
     # create dict that maps keywords to lists of dicts
     # Validate that nothing is in the leftover fields
     # Alert about whitespaces
+
+    return data, violations

--- a/yml2block/tsv_input.py
+++ b/yml2block/tsv_input.py
@@ -7,17 +7,6 @@ import itertools
 
 from yml2block.rules import LintViolation
 
-# def _trim_to_header(line, length):
-#     """Trim leading and trailing tabs from a tsv chunk to given nr of columns.
-
-#     The three parts of a Dataverse TSV file are themselves valid tsv.
-#     However, they all start with leadingall lines but the header start
-#     with a leading empty column and the shorter sections contain several
-#     empty trailing columns.
-#     """
-#     _leading_tab, *fields = line.strip("\n").split("\t")
-#     return "\t".join(fields[:length])
-
 
 def _identify_break_points(full_file):
     """Identify where to split the metadata block into its three subsections"""
@@ -49,11 +38,14 @@ def _identify_break_points(full_file):
 
 
 def read_tsv(tsv_path):
+    """Read in a Dataverse TSV metadata block file."""
     violations = []
+    data = dict()
 
     with open(tsv_path, "r") as raw_file:
         full_file = raw_file.readlines()
 
+    # Split metadata schema into blocks
     split_blocks, break_point_violations = _identify_break_points(full_file)
     violations.extend(break_point_violations)
 
@@ -66,39 +58,44 @@ def read_tsv(tsv_path):
         joined = io.StringIO("\n".join(block))
         return csv.DictReader(joined, delimiter="\t")
 
-    md_fields, ds_fields, vocab_fields = [_parse(block) for block in split_blocks]
-    data = dict()
+    # Unpack each tsv-chunk of the metadata block into a list
+    # of dictionaries.
+    parsed_blocks = [_parse(block) for block in split_blocks]
 
-    def print_dict(d):
-        for r in d:
-            print(r)
+    for row in itertools.chain(*parsed_blocks):
+        # Each row corresponds to a line in the TSV file
+        # unpacked into a dictionary with keys depending
+        # on the part of the block identified by the top level keyword
 
-    # print_dict(md_fields)
-    # print_dict(ds_fields)
-    # print_dict(vocab_fields)
-
-    for row in itertools.chain(*(md_fields, ds_fields, vocab_fields)):
-        toplevel_key_with_hash = [
+        # Get the toplevel keyword from the first column of the TSV file
+        # e.g. #metadataBlock, #datasetField, #controlledVocabulary
+        toplevel_key_with_prefix = [
             entry for entry in row.keys() if entry is not None and entry.startswith("#")
         ][0]
-        toplevel_key = toplevel_key_with_hash.lstrip("#")
+
+        # For consistency with the yaml format
+        toplevel_key = toplevel_key_with_prefix.lstrip("#")
         row_as_dict = dict()
 
         for key, value in row.items():
             if key is None:
+                # These entries cannot be associated with a column header
                 violations.append(
                     LintViolation("ERROR", "read_tsv", "Entry in headerless column")
                 )
-            elif key is toplevel_key_with_hash:
+            elif key is toplevel_key_with_prefix:
+                # Skip toplevel header identifiers. These columns are empty in
+                # Dataverse TSV files
                 continue
             else:
+                # Copy all other entries into a new data structure for this row
                 row_as_dict[key] = value
+
+        # Initialize the entry for this toplevel keyword with an empty list
         if not (toplevel_key in data.keys()):
             data[toplevel_key] = []
-        data[toplevel_key].append(row_as_dict)
 
-    print(data)
-    # clip off keyword
+        data[toplevel_key].append(row_as_dict)
 
     # Run top_level_keywords_valid here to make sure that the generated
     # data structure behaves as expected down the line

--- a/yml2block/tsv_input.py
+++ b/yml2block/tsv_input.py
@@ -1,0 +1,43 @@
+def _trim_to_header(line, length):
+    """Trim leading and trailing tabs from a tsv chunk to given nr of columns.
+
+    The three parts of a Dataverse TSV file are themselves valid tsv.
+    However, they all start with leadingall lines but the header start
+    with a leading empty column and the shorter sections contain several
+    empty trailing columns.
+    """
+    _leading_tab, *fields = line.strip("\n").split("\t")
+    return "\t".join(fields[:length])
+
+
+def read_tsv(tsv_path):
+    with open(md_block_csv, "r") as raw_file:
+        mdb_lines = raw_file.readlines()
+
+    # Extract all keyword lines
+    keyword_lines = [line for line in mdb_lines if line.startswith("#")]
+
+    kw_indices = {}
+    for kw_line in keyword_lines:
+        mdb_keyword, *header_fields = kw_line.strip("\n\t").split("\t")
+
+        # Some header fields in the metadata blocks supplied by the
+        # Dataverse repo have additional whitespaces.
+        # most notably the fieldType column has a leading space
+        # in most metadata blocks. This stripping weakens the lint,
+        # but ensures that the files provided by dataverse check out
+        # as valid.
+        header_fields = [hf.strip(" ") for hf in header_fields]
+
+        # Keep the position of the keyword in the lines
+        # to later split the blocks.
+        kw_indices[mdb_keyword] = mdb_lines.index(kw_line)
+
+    # Compute boundaries between different sections (name, fields, vocab)
+    # of the metadata block
+    ds_fields_start = kw_indices["#datasetField"] + 1
+    if "#controlledVocabulary" in kw_indices:
+        ds_fields_stop = kw_indices["#controlledVocabulary"]
+    else:
+        # In case no controlled vocab was defined, read to the end
+        ds_fields_stop = None

--- a/yml2block/validation.py
+++ b/yml2block/validation.py
@@ -16,9 +16,7 @@ def validate_yaml(data, verbose):
 
 
 def validate_keywords(keywords, verbose):
-    """Assure that the top-level keywords of the YAML file are well-behaved.
-
-    Fail with an assertion if they do not comply."""
+    """Assure that the top-level keywords of the YAML file are well-behaved."""
     if verbose == 1:
         print("Validating top-level keywords:", end=" ")
     elif verbose >= 2:

--- a/yml2block/yaml_input.py
+++ b/yml2block/yaml_input.py
@@ -4,9 +4,10 @@ from ruamel.yaml import YAML
 from ruamel.yaml.constructor import DuplicateKeyError
 
 from yml2block.rules import LintViolation
+from yml2block import validation
 
 
-def read_yaml(file_path):
+def read_yaml(file_path, verbose):
     """Read in a yaml file and convert it into a python dictionary structure."""
     with open(file_path, "r") as yml_file:
         yaml = YAML(typ="safe")
@@ -23,4 +24,4 @@ def read_yaml(file_path):
                     dke.problem,
                 )
             ]
-    return longest_row, file_lint_violations
+    return data, longest_row, file_lint_violations

--- a/yml2block/yaml_input.py
+++ b/yml2block/yaml_input.py
@@ -1,0 +1,26 @@
+"""Import module for YAML files.
+"""
+from ruamel.yaml import YAML
+from ruamel.yaml.constructor import DuplicateKeyError
+
+from yml2block.rules import LintViolation
+
+
+def read_yaml(file_path):
+    """Read in a yaml file and convert it into a python dictionary structure."""
+    with open(file_path, "r") as yml_file:
+        yaml = YAML(typ="safe")
+        try:
+            data = yaml.load(yml_file)
+            longest_row, file_lint_violations = validation.validate_yaml(data, verbose)
+        except DuplicateKeyError as dke:
+            longest_row = 0
+            # Raise error for duplicate keys
+            file_lint_violations = [
+                rules.LintViolation(
+                    "ERROR",
+                    "top_level_keywords_valid",
+                    dke.problem,
+                )
+            ]
+    return longest_row, file_lint_violations


### PR DESCRIPTION
This PR adds the option to read Dataverse TSV files.

These files are converted into the dictionary-style format read from YAML files and linted according to the same rules.
However, no output is generated, i.e. passing a TSV file implies the `--check` parameter.

Currently there are no tests for this functionality and the reporting will be improved in a subsequent PR.