### PR TITLE
Make it installable via pip (PEP-517)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,11 @@ To use `yml2block` you will need the following Python packages
 
 and use Python 3.10 or newer.
 
-Currently, the only way to install is from this GitHub repo.
-After cloning, you can install `yml2block` and its requirements using `poetry`:
+You can install this repository via `pip`:
+```bash
+pip install git+https://github.com/HenningTimm/yml2block.git
+```
+For manual installation after cloning, you can install `yml2block` and its requirements using `poetry`:
 
 ```bash
 ~ $ git clone https://github.com/HenningTimm/yml2block.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
 [tool.poetry]
 name = "yml2block"
 version = "0.5.0"


### PR DESCRIPTION
I noticed that you mentioned in the README that this is only installable via `poetry` so far. 
Thanks to PEP-517, it is very easy to make python projects installable via `pip` also, which is super nice for someone who quickly wants to test this. 

I added the PEP-517 compatibility as described in the poetry docs [here](https://python-poetry.org/docs/pyproject/#poetry-and-pep-517). I also updated the README to explain how to install this via pip.