### PR TITLE
Fix numerical watermarks

### DIFF
--- a/yml2block/rules.py
+++ b/yml2block/rules.py
@@ -427,8 +427,8 @@ def no_trailing_spaces(list_item, tsv_keyword, level=Level.ERROR):
 
     for entry in entries_to_check[tsv_keyword]:
         try:
-            # Make sure that value is a string since re.search can
-            # only work with that, not e.g. int.
+            # Ensure 'value' is a string, as re.search requires
+            # string input, not a numerical type like int.
             value = str(list_item[entry].value)
         except KeyError:
             # This case occurs, when a typo in one of the required

--- a/yml2block/rules.py
+++ b/yml2block/rules.py
@@ -427,7 +427,9 @@ def no_trailing_spaces(list_item, tsv_keyword, level=Level.ERROR):
 
     for entry in entries_to_check[tsv_keyword]:
         try:
-            value = list_item[entry].value
+            # Make sure that value is a string since re.search can
+            # only work with that, not e.g. int.
+            value = str(list_item[entry].value)
         except KeyError:
             # This case occurs, when a typo in one of the required
             # keywords is present. They can safely be skipped here,


### PR DESCRIPTION
re.search only works with strings and we might end up passing an integer instead if number-only watermarks are used.

Closes #19 