### PR TITLE
Conversion and unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ yml2block.egg-info
 poetry.lock
 yml2block/__pycache__/
 tests/__pycache__/
+tests/valid/*_converted.tsv

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ build
 yml2block.egg-info
 poetry.lock
 yml2block/__pycache__/
-tests/__pycache__/
+tests/__pychache__/

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ build
 yml2block.egg-info
 poetry.lock
 yml2block/__pycache__/
-tests/__pychache__/
+tests/__pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Version 0.7.0 (2024-12-??)
+## Version 0.7.0 (2024-12-10)
 
 - Fixed bug where converting files without lint violations would result in an error (#16). Thanks @Athemis
 - Fixed bug where non-string watermarks caused an error (#19). Thanks @Athemis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
-## Version 0.7.0 (2024-11-??)
+## Version 0.7.0 (2024-12-??)
 
 - Fixed bug where converting files without lint violations would result in an error (#T16). Thanks @Athemis
+- Added minimal test for conversion function.
+- Add tests to PRs.
+- Add lint `b003` that checks if all titles within the DatasetField block are unique.
 
 
 ## Version 0.6.0 (2024-03-18)

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -33,8 +33,6 @@ def test_minimal_valid_example_convert():
         yml2block.__main__.main,
         ["convert", "tests/valid/minimal_working_example.yml", "-o", path_output],
     )
-    print(result)
-    print(result.stdout)
     assert result.exit_code == 0, result.stdout
     with open(path_output, "r") as converted_file, open(
         path_expected, "r"

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -8,14 +8,39 @@ def test_basic_execution_works():
     result = runner.invoke(yml2block.__main__.main, ["--help"])
     assert result.exit_code == 0, result
 
+    result = runner.invoke(yml2block.__main__.main, ["check", "--help"])
+    assert result.exit_code == 0, result
 
-def test_minimal_valid_example():
-    """This test ensures that a valid file is translated without throwing an error."""
+    result = runner.invoke(yml2block.__main__.main, ["convert", "--help"])
+    assert result.exit_code == 0, result
+
+
+def test_minimal_valid_example_check():
+    """This test ensures that a valid files do not throw errors during check."""
     runner = CliRunner()
     result = runner.invoke(
         yml2block.__main__.main, ["check", "tests/valid/minimal_working_example.yml"]
     )
     assert result.exit_code == 0, result
+
+
+def test_minimal_valid_example_convert():
+    """This test ensures that a valid file is translated without throwing an error."""
+    runner = CliRunner()
+    path_expected = "tests/valid/minimal_working_example_expected.tsv"
+    path_output = "/tmp/y2b_mwe.tsv"
+    result = runner.invoke(
+        yml2block.__main__.main, ["convert", "tests/valid/minimal_working_example.yml", "-o", path_output]
+    )
+    print(result)
+    print(result.stdout)
+    assert result.exit_code == 0, result.stdout
+    with open(path_output, "r") as converted_file, open(path_expected, "r") as expected_file:
+        converted_tsv = converted_file.read()
+        expected_tsv = expected_file.read()
+        assert converted_tsv == expected_tsv
+        assert len(converted_tsv) > 0
+        assert len(expected_tsv) > 0
 
 
 def test_duplicate_names_detected():

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -30,12 +30,15 @@ def test_minimal_valid_example_convert():
     path_expected = "tests/valid/minimal_working_example_expected.tsv"
     path_output = "/tmp/y2b_mwe.tsv"
     result = runner.invoke(
-        yml2block.__main__.main, ["convert", "tests/valid/minimal_working_example.yml", "-o", path_output]
+        yml2block.__main__.main,
+        ["convert", "tests/valid/minimal_working_example.yml", "-o", path_output],
     )
     print(result)
     print(result.stdout)
     assert result.exit_code == 0, result.stdout
-    with open(path_output, "r") as converted_file, open(path_expected, "r") as expected_file:
+    with open(path_output, "r") as converted_file, open(
+        path_expected, "r"
+    ) as expected_file:
         converted_tsv = converted_file.read()
         expected_tsv = expected_file.read()
         assert converted_tsv == expected_tsv

--- a/tests/snippets/four_item_snippet.tsv
+++ b/tests/snippets/four_item_snippet.tsv
@@ -1,0 +1,4 @@
+#metadataBlock
+#datasetField
+#controlledVocabulary
+#controlledVocabulary

--- a/tests/snippets/minimal_snippet.tsv
+++ b/tests/snippets/minimal_snippet.tsv
@@ -1,0 +1,2 @@
+#metadataBlock
+#datasetField

--- a/tests/snippets/one_item_snippet.tsv
+++ b/tests/snippets/one_item_snippet.tsv
@@ -1,0 +1,1 @@
+#metadataBlock

--- a/tests/snippets/three_item_snippet.tsv
+++ b/tests/snippets/three_item_snippet.tsv
@@ -1,0 +1,3 @@
+#metadataBlock
+#datasetField
+#controlledVocabulary

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -132,7 +132,44 @@ def test_breakpoint_identification():
             ),
             "expected_violations": [],
         },
-        # TODO more test cases
+        {
+            "file": "tests/snippets/minimal_snippet.tsv",
+            "expected_blocks": (
+                "#metadataBlock\n",
+                "#datasetField\n",
+                None,
+            ),
+            "expected_violations": [],
+        },
+        {
+            "file": "tests/snippets/three_item_snippet.tsv",
+            "expected_blocks": (
+                "#metadataBlock\n",
+                "#datasetField\n",
+                "#controlledVocabulary\n",
+            ),
+            "expected_violations": [],
+        },
+        {
+            "file": "tests/snippets/one_item_snippet.tsv",
+            "expected_blocks": "#metadataBlock\n",
+            "expected_violations": [
+                {
+                    "level": Level.WARNING,
+                    "rule": "identify_break_points",
+                }
+            ],
+        },
+        {
+            "file": "tests/snippets/four_item_snippet.tsv",
+            "expected_blocks": "#metadataBlock\n#datasetField\n#controlledVocabulary\n#controlledVocabulary\n",
+            "expected_violations": [
+                {
+                    "level": Level.WARNING,
+                    "rule": "identify_break_points",
+                }
+            ],
+        },
     ]
 
     for test_case in test_cases:
@@ -141,7 +178,8 @@ def test_breakpoint_identification():
         assert split_blocks == test_case["expected_blocks"]
         assert len(violations) == len(test_case["expected_violations"])
         for vio, exp_vio in zip(violations, test_case["expected_violations"]):
-            assert vio == exp_vio
+            assert vio.level == exp_vio["level"]
+            assert vio.rule == exp_vio["rule"]
 
 
 def test_breakpoint_suggestions():

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -116,4 +116,4 @@ def test_input_guessing_invalid_extension():
         guessed_type, violations = guess_input_type(path)
         assert len(violations) == 1
         assert violations[0].level == Level.ERROR
-        assert guessed_type == False
+        assert guessed_type is False

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1,5 +1,6 @@
 from yml2block.__main__ import guess_input_type
 from yml2block.rules import Level
+from yml2block.tsv_input import _identify_break_points
 
 
 def test_input_guessing_valid_tsv():
@@ -117,3 +118,32 @@ def test_input_guessing_invalid_extension():
         assert len(violations) == 1
         assert violations[0].level == Level.ERROR
         assert guessed_type is False
+
+
+def test_breakpoint_identification():
+    """ """
+    test_cases = [
+        {
+            "file": "tests/valid/minimal_working_example_expected.tsv",
+            "expected_blocks": (
+                "#metadataBlock\tname\tdataverseAlias\tdisplayName\t\t\t\t\t\t\t\t\t\t\t\t\n\tValidExample\t\tValid\t\t\t\t\t\t\t\t\t\t\t\t\n",
+                "#datasetField\tname\ttitle\tdescription\twatermark\tfieldType\tdisplayOrder\tdisplayFormat\tadvancedSearchField\tallowControlledVocabulary\tallowmultiples\tfacetable\tdisplayoncreate\trequired\tparent\tmetadatablock_id\n\tDescription\tDescription\tThis field describes.\t\ttextbox\t\t\tTRUE\tFALSE\tFALSE\tFALSE\tTRUE\tTRUE\t\tValidExample\n\tAnswer\tAnswer\t\t\ttext\t\t\tTRUE\tTRUE\tTRUE\tTRUE\tTRUE\tTRUE\t\tValidExample\n",
+                "#controlledVocabulary\tDatasetField\tValue\tidentifier\tdisplayOrder\t\t\t\t\t\t\t\t\t\t\t\n\tAnswerYes\tYes\tanswer_positive\t\t\t\t\t\t\t\t\t\t\t\t\n\tAnswerNo\tNo\tanswer_negative\t\t\t\t\t\t\t\t\t\t\t\t\n\tAnswerMaybeSo\tMaybe\tanswer_unclear\t\t\t\t\t\t\t\t\t\t\t\t\n",
+            ),
+            "expected_violations": [],
+        },
+        # TODO more test cases
+    ]
+
+    for test_case in test_cases:
+        with open(test_case["file"], "r") as case_file:
+            split_blocks, violations = _identify_break_points(case_file.read())
+        assert split_blocks == test_case["expected_blocks"]
+        assert len(violations) == len(test_case["expected_violations"])
+        for vio, exp_vio in zip(violations, test_case["expected_violations"]):
+            assert vio == exp_vio
+
+
+def test_breakpoint_suggestions():
+    """ """
+    raise NotImplemented

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -175,8 +175,13 @@ def test_breakpoint_identification():
     for test_case in test_cases:
         with open(test_case["file"], "r") as case_file:
             split_blocks, violations = _identify_break_points(case_file.read())
+
+        # Ensure the expected blocks are returned
+        # and that the correct number is returned
         assert split_blocks == test_case["expected_blocks"]
         assert len(violations) == len(test_case["expected_violations"])
+
+        # Ensure the expected error are detected
         for vio, exp_vio in zip(violations, test_case["expected_violations"]):
             assert vio.level == exp_vio["level"]
             assert vio.rule == exp_vio["rule"]

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -180,8 +180,3 @@ def test_breakpoint_identification():
         for vio, exp_vio in zip(violations, test_case["expected_violations"]):
             assert vio.level == exp_vio["level"]
             assert vio.rule == exp_vio["rule"]
-
-
-def test_breakpoint_suggestions():
-    """ """
-    raise NotImplemented

--- a/tests/valid/minimal_working_example_expected.tsv
+++ b/tests/valid/minimal_working_example_expected.tsv
@@ -1,0 +1,9 @@
+#metadataBlock	name	dataverseAlias	displayName												
+	ValidExample		Valid												
+#datasetField	name	title	description	watermark	fieldType	displayOrder	displayFormat	advancedSearchField	allowControlledVocabulary	allowmultiples	facetable	displayoncreate	required	parent	metadatablock_id
+	Description	Description	This field describes.		textbox			TRUE	FALSE	FALSE	FALSE	TRUE	TRUE		ValidExample
+	Answer	Answer			text			TRUE	TRUE	TRUE	TRUE	TRUE	TRUE		ValidExample
+#controlledVocabulary	DatasetField	Value	identifier	displayOrder											
+	AnswerYes	Yes	answer_positive												
+	AnswerNo	No	answer_negative												
+	AnswerMaybeSo	Maybe	answer_unclear												

--- a/yml2block/__main__.py
+++ b/yml2block/__main__.py
@@ -145,7 +145,9 @@ def return_violations(lint_violations, warn_ec, verbose):
             print("Errors detected. File(s) cannot safely be converted to TSV.")
             sys.exit(1)
         elif max_severity == Level.WARNING:
-            print("Warnings detected. File(s) can probably not be safely converted to TSV.")
+            print(
+                "Warnings detected. File(s) can probably not be safely converted to TSV."
+            )
             sys.exit(warn_ec)
         elif max_severity == Level.NONE:
             print("\nAll Checks passed! 🎉 Safe covnersion is possible.\n\n")

--- a/yml2block/__main__.py
+++ b/yml2block/__main__.py
@@ -152,7 +152,7 @@ def return_violations(lint_violations, warn_ec, verbose):
             )
             sys.exit(warn_ec)
         elif max_severity == Level.NONE:
-            print("\nAll Checks passed! 🎉 Safe covnersion is possible.\n\n")
+            print("\nAll Checks passed! 🎉 Safe conversion is possible.\n\n")
             sys.exit(0)
         else:
             sys.exit(1)

--- a/yml2block/__main__.py
+++ b/yml2block/__main__.py
@@ -55,10 +55,12 @@ class ViolationsByFile:
     def __iter__(self):
         """Iterate over violations and max severity level per file."""
         for filename, violations in self.violations.items():
-            yield (filename, violations, min(violations, key=lambda x: x.level).level)
-
+            yield (filename, violations, self.max_severity(filename))
 
     def max_severity(self, file_path):
+        """Get the highest error severity level for the file and Level.NONE
+        if the file has no violations.
+        """
         try:
             violation_list = self.violations[file_path]
             if len(violation_list) == 0:

--- a/yml2block/__main__.py
+++ b/yml2block/__main__.py
@@ -123,7 +123,7 @@ def return_violations(lint_violations, warn_ec, verbose):
 
     if len(lint_violations) == 0:
         if verbose:
-            print("\nAll Checks passed!\n\n")
+            print("\nAll Checks passed! 🎉\n\n")
         sys.exit(0)
     else:
         max_severity = None
@@ -133,15 +133,23 @@ def return_violations(lint_violations, warn_ec, verbose):
             print()
             print(file_path)
             print(100 * "-")
-            print(f"A total of {len(violations)} lint(s) failed.")
-            print(f"Highest error level was '{max_severity.name}'")
-            for violation in violations:
-                print(violation)
-        print("Errors detected. File(s) cannot safely be converted to TSV.")
+            if violations:
+                print(f"A total of {len(violations)} lint(s) failed.")
+                print(f"Highest error level was '{max_severity.name}'")
+                for violation in violations:
+                    print(violation)
+            else:
+                print(f"All checks passed for {file_path}! 🎉")
+
         if max_severity == Level.ERROR:
+            print("Errors detected. File(s) cannot safely be converted to TSV.")
             sys.exit(1)
         elif max_severity == Level.WARNING:
+            print("Warnings detected. File(s) can probably not be safely converted to TSV.")
             sys.exit(warn_ec)
+        elif max_severity == Level.NONE:
+            print("\nAll Checks passed! 🎉 Safe covnersion is possible.\n\n")
+            sys.exit(0)
         else:
             sys.exit(1)
 

--- a/yml2block/rules.py
+++ b/yml2block/rules.py
@@ -137,6 +137,7 @@ class LintConfig:
 class Level(IntEnum):
     """Provide numeric error levels."""
 
+    NONE = 3
     WARNING = 2
     ERROR = 1
 

--- a/yml2block/suggestions.py
+++ b/yml2block/suggestions.py
@@ -58,3 +58,24 @@ def fix_required_keys_present(missing_keys, list_item, tsv_keyword):
     """Return list of missing keys."""
     name = identify_entry(list_item, tsv_keyword)
     return f"Missing keys '{missing_keys}' for '{name}' in block '{tsv_keyword}'."
+
+
+def fix_identify_breaking_points(full_file, break_points):
+    """Suggest fixes for too little or too many detected blocks."""
+    match len(break_points):
+        case 0:
+            # No line starts with #
+            # are you passing the right file?
+            ...
+        case 1:
+            # Only one line starts with #
+            # At least two blocks are required for a reasonable metadata schema
+            ...
+        case 2 | 3:
+            # This case should never be reached, those files are fine
+            # Raise an exception if I get here in error handling
+            ...
+        case _:
+            # More than the required number of blocks is present.
+            # Identify what is going on.
+            ...


### PR DESCRIPTION
This PR adds a rework of severity level management. Severity levels, including the level NONE that indicates a file/test without violations are now used in all returns. On the user side, this PR introduces the following changes:

- A minimal conversion test that converts a yml to tsv file.
- Tests are now run and required for PRs.
- Add lint `b003` that checks if all titles within the DatasetField block are unique.