### PR TITLE
Error Flag and Lint Refinement

### DIFF
--- a/.github/workflows/tests_and_lints.yml
+++ b/.github/workflows/tests_and_lints.yml
@@ -17,7 +17,7 @@ jobs:
           - "3.13"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: psf/black@stable
         with:
@@ -25,7 +25,7 @@ jobs:
           src: "yml2block/"
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/tests_and_lints.yml
+++ b/.github/workflows/tests_and_lints.yml
@@ -11,8 +11,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.10"
-          - "3.11"
           - "3.12"
           - "3.13"
 

--- a/.github/workflows/tests_and_lints.yml
+++ b/.github/workflows/tests_and_lints.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-versions:
+        python-version:
           - "3.10"
           - "3.11"
           - "3.12"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,37 @@
 # Changelog
 
+## Version 0.8.0 (2025-01-01)
+
+### Lint Changes
+
+- Added lints (e005 and e006) to detect [nested compound metadata](https://github.com/IQSS/dataverse/issues/9911).
+- Demote e004 to be a warning by default (Fixes https://github.com/HenningTimm/yml2block/issues/23).
+  Since Dataverse 6.5, trailing whitespaces [are trimmed](https://github.com/IQSS/dataverse/pull/10696).
+- Tweak `unique_title` (b003) lint to allow identical titles as long as
+  they are part of different compound field. (Fixed https://github.com/HenningTimm/yml2block/issues/22)
+
+### CLI Changes
+
+- Add `--error` flag that allows warnings to be treated as errors instead.
+
+### Test Changes
+
+- Fixed multi version tests not working properly
+
+### Other Changes
+
+- Dropped support for Python versions below 3.12 for better string formatting (cf. [PEP 701](https://peps.python.org/pep-0701/))
+
+
+
 ## Version 0.7.0 (2024-12-10)
 
-- Fixed bug where converting files without lint violations would result in an error (#16). Thanks @Athemis
-- Fixed bug where non-string watermarks caused an error (#19). Thanks @Athemis
+- Fixed bug where converting files without lint violations would result in an error (https://github.com/HenningTimm/yml2block/issues/16). Thanks @Athemis
+- Fixed bug where non-string watermarks caused an error (https://github.com/HenningTimm/yml2block/issues/19). Thanks @Athemis
 - Added minimal test for conversion function.
 - Add tests to PRs.
 - Add lint `b003` that checks if all titles within the DatasetField block are unique.
+
 
 ## Version 0.6.0 (2024-03-18)
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ You can explicitly specify an output file name using the `-o file/path.tsv` para
 
 All checks performed during the `check` and `convert` commands are described in the file `RULES.md`.
 Each rule can be toggled to be a warning instead of an error using the `--warn` parameter and
-skipped entirely by using the `--skip` parameter. Both need to be followed by a rule name
+skipped entirely by using the `--skip` parameter. In the same manner, warnings can be treated as
+errors with the `--error` flag. All three need to be followed by a rule name
 or rule id. Both can be found in the file `RULES.md`.
 
 ```bash

--- a/RULES.md
+++ b/RULES.md
@@ -2,16 +2,18 @@
 
 This file contains a list of all lints checked by yml2block.
 
-| Rule Name               | Rule id | Level   | Test                                                                                                      |
-|-------------------------|---------|---------|-----------------------------------------------------------------------------------------------------------|
-| `unique_names`          | b001    | ERROR   | Ensure that within a block (e.g. DatasetField) all names are unique.                                      |
-| `block_is_list`         | b002    | ERROR   | Ensure that each block content is a valid yaml list.                                                      |
-| `unique_titles`         | b003    | ERROR   | Ensure that within the DatasetField block all titles are unique.                                          |
-| `keywords_valid`        | k001    | ERROR   | Ensure top level keywords (i.e. block names) are present and contain no typos.                            |
-| `keywords_unique`       | k002    | ERROR   | Ensure no top level keyword occurs multiple times.                                                        |
-| `keys_valid`            | e001    | ERROR   | Ensure that no invalid keys are present, e.g. through typos.                                              |
-| `required_keys_present` | e002    | ERROR   | Ensure that all required keys for the block entry are present (e.g. DatasetField has a name, etc. ...).   |
-| `no_substructures`      | e003    | ERROR   | Ensure entries in yaml format have no unexpected substructures but adhere to dataverse-compatible format. |
-| `no_trailing_spaces`    | e004    | WARNING | Ensure that block entries do not have trailing white spaces.                                              |
-|                         |         |         |                                                                                                           |
+| Rule Name                  | Rule id | Level   | Test                                                                                                                                                                                                                             |
+|----------------------------|---------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `unique_names`             | b001    | ERROR   | Ensure that within a block (e.g. DatasetField) all names are unique.                                                                                                                                                             |
+| `block_is_list`            | b002    | ERROR   | Ensure that each block content is a valid yaml list.                                                                                                                                                                             |
+| `unique_titles`            | b003    | ERROR   | Ensure that within the DatasetField block all titles are unique.                                                                                                                                                                 |
+| `keywords_valid`           | k001    | ERROR   | Ensure top level keywords (i.e. block names) are present and contain no typos.                                                                                                                                                   |
+| `keywords_unique`          | k002    | ERROR   | Ensure no top level keyword occurs multiple times.                                                                                                                                                                               |
+| `keys_valid`               | e001    | ERROR   | Ensure that no invalid keys are present, e.g. through typos.                                                                                                                                                                     |
+| `required_keys_present`    | e002    | ERROR   | Ensure that all required keys for the block entry are present (e.g. DatasetField has a name, etc. ...).                                                                                                                          |
+| `no_substructures`         | e003    | ERROR   | Ensure entries in yaml format have no unexpected substructures but adhere to dataverse-compatible format.                                                                                                                        |
+| `no_trailing_spaces`       | e004    | WARNING | Ensure that block entries do not have trailing white spaces.                                                                                                                                                                     |
+| `nested_compound_metadata` | e005    | WARNING | Ensure no nested compound metadata are present (cf. https://github.com/IQSS/dataverse/issues/9911). Entries with controlled vocabs are more dangerous (ERROR), entries without are acceptable (WARNING).                         |
+| `nested_compound_metadata` | e006    | ERROR   | Ensure no nested compound metadata using controlled vocabs are present (cf. https://github.com/IQSS/dataverse/issues/9911). Entries with controlled vocabs are more dangerous (ERROR), entries without are acceptable (WARNING). |
+|                            |         |         |                                                                                                                                                                                                                                  |
 

--- a/RULES.md
+++ b/RULES.md
@@ -2,15 +2,16 @@
 
 This file contains a list of all lints checked by yml2block.
 
-| Rule Name               | Rule id | Test |
-|-------------------------|---------|------|
-| `unique_names`          | b001    | Ensure that within a block (e.g. DatasetField) all names are unique. |
-| `block_is_list`         | b002    | Ensure that each block content is a valid yaml list. |
-| `unique_titles`         | b003    | Ensure that within the DatasetField block all titles are unique. |
-| `keywords_valid`        | k001    | Ensure top level keywords (i.e. block names) are present and contain no typos. |
-| `keywords_unique`       | k002    | Ensure no top level keyword occurs multiple times. |
-| `keys_valid`            | e001    | Ensure that no invalid keys are present, e.g. through typos. |
-| `required_keys_present` | e002    | Ensure that all required keys for the block entry are present (e.g. DatasetField has a name, etc. ...). |
-| `no_substructures`      | e003    | Ensure entries in yaml format have no unexpected substructures but adhere to dataverse-compatible format. |
-| `no_trailing_spaces`    | e004    | Ensure that block entries do not have trailing white spaces. |
+| Rule Name               | Rule id | Level   | Test                                                                                                      |
+|-------------------------|---------|---------|-----------------------------------------------------------------------------------------------------------|
+| `unique_names`          | b001    | ERROR   | Ensure that within a block (e.g. DatasetField) all names are unique.                                      |
+| `block_is_list`         | b002    | ERROR   | Ensure that each block content is a valid yaml list.                                                      |
+| `unique_titles`         | b003    | ERROR   | Ensure that within the DatasetField block all titles are unique.                                          |
+| `keywords_valid`        | k001    | ERROR   | Ensure top level keywords (i.e. block names) are present and contain no typos.                            |
+| `keywords_unique`       | k002    | ERROR   | Ensure no top level keyword occurs multiple times.                                                        |
+| `keys_valid`            | e001    | ERROR   | Ensure that no invalid keys are present, e.g. through typos.                                              |
+| `required_keys_present` | e002    | ERROR   | Ensure that all required keys for the block entry are present (e.g. DatasetField has a name, etc. ...).   |
+| `no_substructures`      | e003    | ERROR   | Ensure entries in yaml format have no unexpected substructures but adhere to dataverse-compatible format. |
+| `no_trailing_spaces`    | e004    | WARNING | Ensure that block entries do not have trailing white spaces.                                              |
+|                         |         |         |                                                                                                           |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "yml2block"
-version = "0.6.0"
+version = "0.8.0"
 description = "Converts yaml files describing dataverse metadata blocks into tsv files understood by dataverse."
 license = "MIT"
 authors = [
@@ -32,7 +32,7 @@ packages = [
 yml2block = 'yml2block.__main__:main'
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.12"
 # Package names with '.' need quotes to make poetry happy
 "ruamel.yaml" = "^0.17.21"  # Earlier versions might work, but are untested.
 click = "^8.1"  # Earlier versions might work, but are untested.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,8 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
     "Topic :: Utilities",
 ]

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -130,3 +130,29 @@ def test_wrong_extensions_fail():
         yml2block.__main__.main, ["check", "tests/invalid/minimal_example.xlsx"]
     )
     assert result.exit_code == 1, result.output
+
+
+def test_nested_compound_metadata():
+    """Ensure nested compound metadata are detected and classified correctly.
+    """
+
+    runner = CliRunner()
+    result = runner.invoke(
+        yml2block.__main__.main, ["check", "tests/invalid/nested_compound_metadata.yml"]
+    )
+    assert result.exit_code == 1, result.output
+
+    result = runner.invoke(
+        yml2block.__main__.main, ["check", "tests/invalid/nested_compound_metadata.tsv"]
+    )
+    assert result.exit_code == 1, result.output
+
+    result = runner.invoke(
+        yml2block.__main__.main, ["check", "--warn-ec 2", "tests/valid/nested_compound_metadata.yml"]
+    )
+    assert result.exit_code == 2, result.output
+
+    result = runner.invoke(
+        yml2block.__main__.main, ["check", "--warn-ec 2", "tests/valid/nested_compound_metadata.tsv"]
+    )
+    assert result.exit_code == 2, result.output

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -133,8 +133,7 @@ def test_wrong_extensions_fail():
 
 
 def test_nested_compound_metadata():
-    """Ensure nested compound metadata are detected and classified correctly.
-    """
+    """Ensure nested compound metadata are detected and classified correctly."""
 
     runner = CliRunner()
     result = runner.invoke(
@@ -148,11 +147,13 @@ def test_nested_compound_metadata():
     assert result.exit_code == 1, result.output
 
     result = runner.invoke(
-        yml2block.__main__.main, ["check", "--warn-ec 2", "tests/valid/nested_compound_metadata.yml"]
+        yml2block.__main__.main,
+        ["check", "--warn-ec 2", "tests/valid/nested_compound_metadata.yml"],
     )
     assert result.exit_code == 2, result.output
 
     result = runner.invoke(
-        yml2block.__main__.main, ["check", "--warn-ec 2", "tests/valid/nested_compound_metadata.tsv"]
+        yml2block.__main__.main,
+        ["check", "--warn-ec 2", "tests/valid/nested_compound_metadata.tsv"],
     )
     assert result.exit_code == 2, result.output

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -107,15 +107,15 @@ def test_trailing_whitespace_detected():
     """This test ensures that typos in keys are detected."""
     runner = CliRunner()
     result = runner.invoke(
-        yml2block.__main__.main, ["check", "tests/invalid/whitespace_in_key.yml"]
+        yml2block.__main__.main, ["check", "--warn-ec 2", "tests/invalid/whitespace_in_key.yml"]
     )
-    assert result.exit_code == 1, result.output
+    assert result.exit_code == 2, result.output
 
     runner = CliRunner()
     result = runner.invoke(
-        yml2block.__main__.main, ["check", "tests/invalid/whitespace_in_key.tsv"]
+        yml2block.__main__.main, ["check", "--warn-ec 2", "tests/invalid/whitespace_in_key.tsv"]
     )
-    assert result.exit_code == 1, result.output
+    assert result.exit_code == 2, result.output
 
 
 def test_wrong_extensions_fail():

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -77,6 +77,14 @@ def test_duplicate_titles_detected():
     )
     assert result.exit_code == 1, result.output
 
+    # Acceptable duplications are not reported as errors
+    runner = CliRunner()
+    result = runner.invoke(
+        yml2block.__main__.main,
+        ["check", "tests/valid/duplicate_compound_titles.yml"],
+    )
+    assert result.exit_code == 0, result.output
+
 
 def test_duplicate_top_level_key_detected():
     """This test ensures that duplicates in top-level keys are detected."""

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -115,13 +115,15 @@ def test_trailing_whitespace_detected():
     """This test ensures that typos in keys are detected."""
     runner = CliRunner()
     result = runner.invoke(
-        yml2block.__main__.main, ["check", "--warn-ec 2", "tests/invalid/whitespace_in_key.yml"]
+        yml2block.__main__.main,
+        ["check", "--warn-ec 2", "tests/invalid/whitespace_in_key.yml"],
     )
     assert result.exit_code == 2, result.output
 
     runner = CliRunner()
     result = runner.invoke(
-        yml2block.__main__.main, ["check", "--warn-ec 2", "tests/invalid/whitespace_in_key.tsv"]
+        yml2block.__main__.main,
+        ["check", "--warn-ec 2", "tests/invalid/whitespace_in_key.tsv"],
     )
     assert result.exit_code == 2, result.output
 

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -53,7 +53,6 @@ def test_duplicate_names_detected():
     )
     assert result.exit_code == 1, result.output
 
-    runner = CliRunner()
     result = runner.invoke(
         yml2block.__main__.main,
         ["check", "tests/invalid/duplicate_datasetfield_name.tsv"],
@@ -70,7 +69,6 @@ def test_duplicate_titles_detected():
     )
     assert result.exit_code == 1, result.output
 
-    runner = CliRunner()
     result = runner.invoke(
         yml2block.__main__.main,
         ["check", "tests/invalid/duplicate_datasetfield_title.tsv"],
@@ -78,7 +76,6 @@ def test_duplicate_titles_detected():
     assert result.exit_code == 1, result.output
 
     # Acceptable duplications are not reported as errors
-    runner = CliRunner()
     result = runner.invoke(
         yml2block.__main__.main,
         ["check", "tests/valid/duplicate_compound_titles.yml"],
@@ -104,7 +101,6 @@ def test_typo_in_keyword_detected():
     )
     assert result.exit_code == 1, result.output
 
-    runner = CliRunner()
     result = runner.invoke(
         yml2block.__main__.main, ["check", "tests/invalid/typo_in_keyword.tsv"]
     )
@@ -120,7 +116,6 @@ def test_trailing_whitespace_detected():
     )
     assert result.exit_code == 2, result.output
 
-    runner = CliRunner()
     result = runner.invoke(
         yml2block.__main__.main,
         ["check", "--warn-ec 2", "tests/invalid/whitespace_in_key.tsv"],

--- a/tests/invalid/nested_compound_metadata.tsv
+++ b/tests/invalid/nested_compound_metadata.tsv
@@ -1,0 +1,15 @@
+#metadataBlock	name	dataverseAlias	displayName												
+	compound_error		Nested Compound Metadata Error												
+#datasetField	name	title	description	watermark	 fieldType	displayOrder	displayFormat	advancedSearchField	allowControlledVocabulary	allowmultiples	facetable	displayoncreate	required	parent	metadatablock_id
+	compoundParent	Parent	Parent node of nested metadata		none	0		FALSE	FALSE	FALSE	FALSE	TRUE	FALSE		compound_error
+	compoundChild1	Child 1	compound metadata field		text	1		TRUE	TRUE	FALSE	FALSE	TRUE	FALSE	compoundParent	compound_error
+	compoundChild2	Child 2	compound metadata field		text	2		TRUE	TRUE	FALSE	FALSE	TRUE	FALSE	compoundParent	compound_error
+	compoundChild3	Child 3	compound metadata field		text	3		TRUE	FALSE	TRUE	FALSE	TRUE	FALSE	compoundParent	compound_error
+#controlledVocabulary	DatasetField	Value	identifier	displayOrder											
+	compoundChild1	C1 Value A		0											
+	compoundChild1	C1 Value B		1											
+	compoundChild1	C1 Value C		2											
+	compoundChild2	C2 Value D		3											
+	compoundChild2	C2 Value E		2											
+	compoundChild2	C2 Value F		1											
+	compoundChild2	C3 Value F		0											

--- a/tests/invalid/nested_compound_metadata.yml
+++ b/tests/invalid/nested_compound_metadata.yml
@@ -1,0 +1,91 @@
+---
+metadataBlock:
+  - name: NestedCompoundMetadataError
+    dataverseAlias:
+    displayName: Valid
+datasetField:
+  - name: compoundParent
+    title: Parent
+    description: Parent node of nested metadata
+    watermark:
+    fieldType: none
+    displayOrder: 0
+    displayFormat:
+    advancedSearchField: false
+    allowControlledVocabulary: false
+    allowmultiples: false
+    facetable: false
+    displayoncreate: true
+    required: false
+    parent:
+    metadatablock_id: NestedCompoundMetadataError
+  - name: compoundChild1
+    title: child 1
+    description: Nested compound Metadata field with controlled vocab
+    watermark:
+    fieldType: text
+    displayOrder: 1
+    displayFormat:
+    advancedSearchField: true
+    allowControlledVocabulary: true
+    allowmultiples: true
+    facetable: false
+    displayoncreate: true
+    required: false
+    parent: compoundParent
+    metadatablock_id: NestedCompoundMetadataError
+  - name: compoundChild2
+    title: Child 2
+    description: Nested compound Metadata field with controlled vocab
+    watermark:
+    fieldType: text
+    displayOrder: 2
+    displayFormat:
+    advancedSearchField: true
+    allowControlledVocabulary: true
+    allowmultiples: true
+    facetable: false
+    displayoncreate: true
+    required: false
+    parent: compoundParent
+    metadatablock_id: NestedCompoundMetadataError
+  - name: compoundChild3
+    title: Child 3
+    description: Nested compound Metadata field WITHOUT controlled vocab
+    watermark:
+    fieldType: text
+    displayOrder: 3
+    displayFormat:
+    advancedSearchField: true
+    allowControlledVocabulary: false
+    allowmultiples: true
+    facetable: false
+    displayoncreate: true
+    required: false
+    parent: compoundParent
+    metadatablock_id: NestedCompoundMetadataError
+controlledVocabulary:
+  - DatasetField: compoundChild1 
+    Value: "C1 Value A"
+    identifier: 
+    displayOrder:
+  - DatasetField: compoundChild1 
+    Value: "C1 Value B"
+    identifier: 
+    displayOrder:
+  - DatasetField: compoundChild1 
+    Value: "C1 Value C"
+    identifier: 
+    displayOrder:
+  - DatasetField: compoundChild2 
+    Value: "C2 Value D"
+    identifier: 
+    displayOrder:
+  - DatasetField: compoundChild2 
+    Value: "C2 Value E"
+    identifier: 
+    displayOrder:
+  - DatasetField: compoundChild2 
+    Value: "C2 Value F"
+    identifier: 
+    displayOrder:

--- a/tests/invalid/nested_compound_metadata.yml
+++ b/tests/invalid/nested_compound_metadata.yml
@@ -42,21 +42,6 @@ datasetField:
     displayOrder: 2
     displayFormat:
     advancedSearchField: true
-    allowControlledVocabulary: true
-    allowmultiples: true
-    facetable: false
-    displayoncreate: true
-    required: false
-    parent: compoundParent
-    metadatablock_id: NestedCompoundMetadataError
-  - name: compoundChild3
-    title: Child 3
-    description: Nested compound Metadata field WITHOUT controlled vocab
-    watermark:
-    fieldType: text
-    displayOrder: 3
-    displayFormat:
-    advancedSearchField: true
     allowControlledVocabulary: false
     allowmultiples: true
     facetable: false
@@ -75,17 +60,5 @@ controlledVocabulary:
     displayOrder:
   - DatasetField: compoundChild1 
     Value: "C1 Value C"
-    identifier: 
-    displayOrder:
-  - DatasetField: compoundChild2 
-    Value: "C2 Value D"
-    identifier: 
-    displayOrder:
-  - DatasetField: compoundChild2 
-    Value: "C2 Value E"
-    identifier: 
-    displayOrder:
-  - DatasetField: compoundChild2 
-    Value: "C2 Value F"
     identifier: 
     displayOrder:

--- a/tests/valid/duplicate_compound_titles.yml
+++ b/tests/valid/duplicate_compound_titles.yml
@@ -28,7 +28,7 @@ datasetField:
     displayFormat:
     advancedSearchField: true
     allowControlledVocabulary: true
-    allowmultiples: true
+    allowmultiples: false
     facetable: true
     displayoncreate: true
     required: true

--- a/tests/valid/duplicate_compound_titles.yml
+++ b/tests/valid/duplicate_compound_titles.yml
@@ -1,0 +1,64 @@
+---
+metadataBlock:
+  - name: ValidExample
+    dataverseAlias:
+    displayName: Valid
+datasetField:
+  - name: Name 1
+    title: Parent Field
+    description: This is a parent field.
+    watermark:
+    fieldType: textbox
+    displayOrder:
+    displayFormat:
+    advancedSearchField: true
+    allowControlledVocabulary: false
+    allowmultiples: false
+    facetable: false
+    displayoncreate: true
+    required: true
+    parent:
+    metadatablock_id: ValidExample
+  - name: Child 1
+    title: Duplicate Title
+    description: This is a child field of Parent Field
+    watermark:
+    fieldType: text
+    displayOrder:
+    displayFormat:
+    advancedSearchField: true
+    allowControlledVocabulary: true
+    allowmultiples: true
+    facetable: true
+    displayoncreate: true
+    required: true
+    parent: Name 1
+    metadatablock_id: ValidExample
+  - name: Name 2
+    title: Duplicate Title
+    description: This is not a child field, so this duplicate title is acceptable.
+    watermark:
+    fieldType: text
+    displayOrder:
+    displayFormat:
+    advancedSearchField: true
+    allowControlledVocabulary: true
+    allowmultiples: true
+    facetable: true
+    displayoncreate: true
+    required: true
+    parent:
+    metadatablock_id: ValidExample
+controlledVocabulary:
+  - DatasetField: AnswerYes
+    Value: "Yes"
+    identifier: answer_positive
+    displayOrder:
+  - DatasetField: AnswerNo
+    Value: "No"
+    identifier: answer_negative
+    displayOrder:
+  - DatasetField: AnswerMaybeSo
+    Value: "Maybe"
+    identifier: answer_unclear
+    displayOrder:

--- a/tests/valid/nested_compound_metadata.tsv
+++ b/tests/valid/nested_compound_metadata.tsv
@@ -1,0 +1,15 @@
+#metadataBlock	name	dataverseAlias	displayName												
+	compound_error		Nested Compound Metadata Error												
+#datasetField	name	title	description	watermark	 fieldType	displayOrder	displayFormat	advancedSearchField	allowControlledVocabulary	allowmultiples	facetable	displayoncreate	required	parent	metadatablock_id
+	compoundParent	Parent	Parent node of nested metadata		none	0		FALSE	FALSE	FALSE	FALSE	TRUE	FALSE		compound_error
+	compoundChild1	Child 1	compound metadata field		text	1		TRUE	TRUE	TRUE	FALSE	TRUE	FALSE	compoundParent	compound_error
+	compoundChild2	Child 2	compound metadata field		text	2		TRUE	TRUE	TRUE	FALSE	TRUE	FALSE	compoundParent	compound_error
+	compoundChild3	Child 3	compound metadata field		text	3		TRUE	FALSE	TRUE	FALSE	TRUE	FALSE	compoundParent	compound_error
+#controlledVocabulary	DatasetField	Value	identifier	displayOrder											
+	compoundChild1	C1 Value A		0											
+	compoundChild1	C1 Value B		1											
+	compoundChild1	C1 Value C		2											
+	compoundChild2	C2 Value D		3											
+	compoundChild2	C2 Value E		2											
+	compoundChild2	C2 Value F		1											
+	compoundChild2	C3 Value F		0											

--- a/tests/valid/nested_compound_metadata.tsv
+++ b/tests/valid/nested_compound_metadata.tsv
@@ -3,13 +3,8 @@
 #datasetField	name	title	description	watermark	 fieldType	displayOrder	displayFormat	advancedSearchField	allowControlledVocabulary	allowmultiples	facetable	displayoncreate	required	parent	metadatablock_id
 	compoundParent	Parent	Parent node of nested metadata		none	0		FALSE	FALSE	FALSE	FALSE	TRUE	FALSE		compound_error
 	compoundChild1	Child 1	compound metadata field		text	1		TRUE	TRUE	TRUE	FALSE	TRUE	FALSE	compoundParent	compound_error
-	compoundChild2	Child 2	compound metadata field		text	2		TRUE	TRUE	TRUE	FALSE	TRUE	FALSE	compoundParent	compound_error
-	compoundChild3	Child 3	compound metadata field		text	3		TRUE	FALSE	TRUE	FALSE	TRUE	FALSE	compoundParent	compound_error
+	compoundChild2	Child 2	compound metadata field		text	2		TRUE	FALSE	TRUE	FALSE	TRUE	FALSE	compoundParent	compound_error
 #controlledVocabulary	DatasetField	Value	identifier	displayOrder											
 	compoundChild1	C1 Value A		0											
 	compoundChild1	C1 Value B		1											
 	compoundChild1	C1 Value C		2											
-	compoundChild2	C2 Value D		3											
-	compoundChild2	C2 Value E		2											
-	compoundChild2	C2 Value F		1											
-	compoundChild2	C3 Value F		0											

--- a/tests/valid/nested_compound_metadata.yml
+++ b/tests/valid/nested_compound_metadata.yml
@@ -1,0 +1,91 @@
+---
+metadataBlock:
+  - name: NestedCompoundMetadataError
+    dataverseAlias:
+    displayName: Valid
+datasetField:
+  - name: compoundParent
+    title: Parent
+    description: Parent node of nested metadata
+    watermark:
+    fieldType: none
+    displayOrder: 0
+    displayFormat:
+    advancedSearchField: false
+    allowControlledVocabulary: false
+    allowmultiples: false
+    facetable: false
+    displayoncreate: true
+    required: false
+    parent:
+    metadatablock_id: NestedCompoundMetadataError
+  - name: compoundChild1
+    title: child 1
+    description: Nested compound Metadata field with controlled vocab
+    watermark:
+    fieldType: text
+    displayOrder: 1
+    displayFormat:
+    advancedSearchField: true
+    allowControlledVocabulary: true
+    allowmultiples: false
+    facetable: false
+    displayoncreate: true
+    required: false
+    parent: compoundParent
+    metadatablock_id: NestedCompoundMetadataError
+  - name: compoundChild2
+    title: Child 2
+    description: Nested compound Metadata field with controlled vocab
+    watermark:
+    fieldType: text
+    displayOrder: 2
+    displayFormat:
+    advancedSearchField: true
+    allowControlledVocabulary: true
+    allowmultiples: false
+    facetable: false
+    displayoncreate: true
+    required: false
+    parent: compoundParent
+    metadatablock_id: NestedCompoundMetadataError
+  - name: compoundChild3
+    title: Child 3
+    description: Nested compound Metadata field WITHOUT controlled vocab
+    watermark:
+    fieldType: text
+    displayOrder: 3
+    displayFormat:
+    advancedSearchField: true
+    allowControlledVocabulary: false
+    allowmultiples: true
+    facetable: false
+    displayoncreate: true
+    required: false
+    parent: compoundParent
+    metadatablock_id: NestedCompoundMetadataError
+controlledVocabulary:
+  - DatasetField: compoundChild1 
+    Value: "C1 Value A"
+    identifier: 
+    displayOrder:
+  - DatasetField: compoundChild1 
+    Value: "C1 Value B"
+    identifier: 
+    displayOrder:
+  - DatasetField: compoundChild1 
+    Value: "C1 Value C"
+    identifier: 
+    displayOrder:
+  - DatasetField: compoundChild2 
+    Value: "C2 Value D"
+    identifier: 
+    displayOrder:
+  - DatasetField: compoundChild2 
+    Value: "C2 Value E"
+    identifier: 
+    displayOrder:
+  - DatasetField: compoundChild2 
+    Value: "C2 Value F"
+    identifier: 
+    displayOrder:

--- a/yml2block/__main__.py
+++ b/yml2block/__main__.py
@@ -166,13 +166,14 @@ def main():
 
 @main.command()
 @click.argument("file_paths", nargs=-1, type=click.Path())
+@click.option("--error", "-e", multiple=True, help="Lints to treat as errors.")
 @click.option("--warn", "-w", multiple=True, help="Lints to treat as warnings.")
 @click.option("--skip", "-s", multiple=True, help="Lints to skip entirely.")
 @click.option(
     "--warn-ec", default=0, help="Error code used for lint warnings. Default: 0"
 )
 @click.option("--verbose", "-v", count=True, help="Print performed checks to stdout.")
-def check(file_paths, warn, skip, warn_ec, verbose):
+def check(file_paths, error, warn, skip, warn_ec, verbose):
     """Lint and validate one or multiple (yml or tsv) metadata block file(s).
 
     Input paths can be one or multiple file names or glob patterns.
@@ -186,7 +187,7 @@ def check(file_paths, warn, skip, warn_ec, verbose):
     are also performed.
     """
     lint_violations = ViolationsByFile()
-    lint_conf = LintConfig.from_cli_args(warn, skip)
+    lint_conf = LintConfig.from_cli_args(error, warn, skip)
 
     # Unpack all file paths as glob patterns
     file_paths = [path for fp in file_paths for path in glob.glob(fp)]
@@ -227,6 +228,7 @@ def check(file_paths, warn, skip, warn_ec, verbose):
 
 @main.command()
 @click.argument("file_path")
+@click.option("--error", "-e", multiple=True, help="Lints to treat as errors.")
 @click.option("--warn", "-w", multiple=True, help="Lints to treat as warnings.")
 @click.option("--skip", "-s", multiple=True, help="Lints to skip entirely.")
 @click.option(
@@ -241,7 +243,7 @@ def check(file_paths, warn, skip, warn_ec, verbose):
 @click.option(
     "--outfile", "-o", nargs=1, help="Path to where the output file will be written."
 )
-def convert(file_path, warn, skip, warn_ec, strict, verbose, outfile):
+def convert(file_path, error, warn, skip, warn_ec, strict, verbose, outfile):
     """Convert a YML metadata block into a TSV metadata block.
 
     Reads in the provided Dataverse Metadata Block in YML format and converts it into
@@ -267,7 +269,7 @@ def convert(file_path, warn, skip, warn_ec, strict, verbose, outfile):
         print(f"Checking input file: {file_path}\n\n")
 
     lint_violations = ViolationsByFile()
-    lint_conf = LintConfig.from_cli_args(warn, skip)
+    lint_conf = LintConfig.from_cli_args(error, warn, skip)
 
     input_type, file_ext_violations = guess_input_type(file_path)
     lint_violations.extend_for(file_path, file_ext_violations)

--- a/yml2block/rules.py
+++ b/yml2block/rules.py
@@ -90,7 +90,11 @@ class LintConfig:
         """Create config using warning and skip lists from CLI."""
         conf = cls()
 
-        for lint, apply_level in [(e, conf.error) for e in error] + [(w, conf.warn) for w in warn] + [(s, conf.skip) for s in skip]:
+        for lint, apply_level in (
+            [(e, conf.error) for e in error]
+            + [(w, conf.warn) for w in warn]
+            + [(s, conf.skip) for s in skip]
+        ):
             try:
                 lint_func = LINT_NAMES[lint]
                 apply_level(lint_func)

--- a/yml2block/rules.py
+++ b/yml2block/rules.py
@@ -457,10 +457,6 @@ def no_trailing_spaces(list_item, tsv_keyword, level=Level.WARNING):
     return violations
 
 
-
-
-
-
 def nested_compound_metadata(list_item, tsv_keyword, level=Level.WARNING):
     """Screen for nested compound metadata (entries that are children, but allow multiple values).
 
@@ -474,10 +470,12 @@ def nested_compound_metadata(list_item, tsv_keyword, level=Level.WARNING):
 
     if tsv_keyword != "datasetField":
         return []
-    
-    if list_item["parent"].value is not None \
-       and list_item["allowmultiples"].value is True \
-       and list_item["allowControlledVocabulary"].value is False:
+
+    if (
+        list_item["parent"].value is not None
+        and list_item["allowmultiples"].value is True
+        and list_item["allowControlledVocabulary"].value is False
+    ):
         violations.append(
             LintViolation(
                 level,
@@ -491,7 +489,9 @@ def nested_compound_metadata(list_item, tsv_keyword, level=Level.WARNING):
     return violations
 
 
-def nested_compound_metadata_controlled_vocab(list_item, tsv_keyword, level=Level.ERROR):
+def nested_compound_metadata_controlled_vocab(
+    list_item, tsv_keyword, level=Level.ERROR
+):
     """Screen for nested compound metadata (entries that are children, but allow multiple values).
 
     This variant checks for compound metadata that do not use a controled vocabulary.
@@ -505,9 +505,11 @@ def nested_compound_metadata_controlled_vocab(list_item, tsv_keyword, level=Leve
     if tsv_keyword != "datasetField":
         return []
 
-    if list_item["parent"].value is not None \
-       and list_item["allowmultiples"].value is True \
-       and list_item["allowControlledVocabulary"].value is True:
+    if (
+        list_item["parent"].value is not None
+        and list_item["allowmultiples"].value is True
+        and list_item["allowControlledVocabulary"].value is True
+    ):
         violations.append(
             LintViolation(
                 level,
@@ -519,8 +521,6 @@ def nested_compound_metadata_controlled_vocab(list_item, tsv_keyword, level=Leve
         )
 
     return violations
-
-
 
 
 LINT_NAMES = {

--- a/yml2block/rules.py
+++ b/yml2block/rules.py
@@ -457,6 +457,72 @@ def no_trailing_spaces(list_item, tsv_keyword, level=Level.WARNING):
     return violations
 
 
+
+
+
+
+def nested_compound_metadata(list_item, tsv_keyword, level=Level.WARNING):
+    """Screen for nested compound metadata (entries that are children, but allow multiple values).
+
+    This variant checks for compound metadata that do not use a controled vocabulary.
+    These are not offered via the dataverse UI and simpy do not work.
+
+    block entry lint
+    """
+
+    violations = []
+
+    if tsv_keyword != "datasetField":
+        return []
+    
+    if list_item["parent"].value is not None \
+       and list_item["allowmultiples"].value is True \
+       and list_item["allowControlledVocabulary"].value is False:
+        violations.append(
+            LintViolation(
+                level,
+                "nested_compound_metadata",
+                f"The entry '{list_item["name"]}' allows multiple entries in a nested field.",
+                list_item["allowmultiples"].line,
+                list_item["allowmultiples"].column,
+            )
+        )
+
+    return violations
+
+
+def nested_compound_metadata_controlled_vocab(list_item, tsv_keyword, level=Level.ERROR):
+    """Screen for nested compound metadata (entries that are children, but allow multiple values).
+
+    This variant checks for compound metadata that do not use a controled vocabulary.
+    These are not offered via the dataverse UI and simpy do not work.
+
+    block entry lint
+    """
+
+    violations = []
+
+    if tsv_keyword != "datasetField":
+        return []
+
+    if list_item["parent"].value is not None \
+       and list_item["allowmultiples"].value is True \
+       and list_item["allowControlledVocabulary"].value is True:
+        violations.append(
+            LintViolation(
+                level,
+                "nested_compound_metadata_controlled_vocab",
+                f"The entry '{list_item["name"]}' allows multiple entries in a nested field.",
+                list_item["allowmultiples"].line,
+                list_item["allowmultiples"].column,
+            )
+        )
+
+    return violations
+
+
+
+
 LINT_NAMES = {
     "unique_names": unique_names,
     "b001": unique_names,
@@ -476,4 +542,8 @@ LINT_NAMES = {
     "e003": no_substructures,
     "no_trailing_spaces": no_trailing_spaces,
     "e004": no_trailing_spaces,
+    "nested_compound_metadata": nested_compound_metadata,
+    "e005": nested_compound_metadata,
+    "nested_compound_metadata_controlled_vocab": nested_compound_metadata_controlled_vocab,
+    "e006": nested_compound_metadata_controlled_vocab,
 }

--- a/yml2block/rules.py
+++ b/yml2block/rules.py
@@ -228,8 +228,11 @@ def unique_titles(yaml_chunk, tsv_keyword, level=Level.ERROR):
     occurrences = defaultdict(list)
 
     for item in yaml_chunk:
+        # Use title parent tuple to allow identical titles
+        # in different compound fields
         item_title = item["title"].value
-        titles.update([item_title])
+        item_parent = item["parent"].value
+        titles.update([(item_title, item_parent)])
         occurrences[item_title].append(item)
 
     errors = []

--- a/yml2block/rules.py
+++ b/yml2block/rules.py
@@ -399,7 +399,7 @@ def no_substructures(list_item, tsv_keyword, level=Level.ERROR):
     return violations
 
 
-def no_trailing_spaces(list_item, tsv_keyword, level=Level.ERROR):
+def no_trailing_spaces(list_item, tsv_keyword, level=Level.WARNING):
     """Make sure the entries do not contain trailing white spaces.
 
     block entry lint

--- a/yml2block/validation.py
+++ b/yml2block/validation.py
@@ -76,6 +76,8 @@ def validate_entry(yaml_chunk, tsv_keyword, lint_conf, verbose):
             rules.required_keys_present,
             rules.no_substructures,
             rules.no_trailing_spaces,
+            rules.nested_compound_metadata,
+            rules.nested_compound_metadata_controlled_vocab,
         ):
             if verbose >= 2:
                 print(f"Running lint: {lint.__name__}")

--- a/yml2block/yaml_input.py
+++ b/yml2block/yaml_input.py
@@ -9,8 +9,8 @@ from yml2block import validation
 
 
 def to_md_block_types(data):
-    """This function takes a ruamel YAML struture and wraps its
-    content into cutsom types that support annotation with line and column
+    """This function takes a ruamel YAML structure and wraps its
+    content into custom types that support annotation with line and column
     numbers to be compatible with the tsv input.
     """
     match data:


### PR DESCRIPTION
This PR adds the CLI flag `--error` that allows lints that are warnings by default to be treated as errors. This change is necessary, since with Dataverse 6.5, whitespaces are automatically trimmed from entries in metadata blocks. This makes the trailing whitespace lint obsolete for v6.5 (#23) and above and thus it is treated as a warning by default now. For older versions, this lint can be reactivated with `--warn e004`.

Further, this PR adds two lints (e005, e006) that screen for nested compound metadata (see #12) and dials back the aggressiveness of b003 (unique titles, see #22).

Finally, this PR fixes the multi version tests and pins the minimal supported Python version to Python 3.12.