### PR TITLE
Yaml line numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Version 0.8.0 (2025-01-01)
+## Version 0.8.0 (2025-01-03)
 
 ### Lint Changes
 
@@ -14,14 +14,11 @@
 
 - Add `--error` flag that allows warnings to be treated as errors instead.
 
-### Test Changes
-
-- Fixed multi version tests not working properly
-
 ### Other Changes
 
+- Fixed multi version tests not working properly
 - Dropped support for Python versions below 3.12 for better string formatting (cf. [PEP 701](https://peps.python.org/pep-0701/))
-
+- Line and column numbers are now reported for "leaves" in yaml input files.
 
 
 ## Version 0.7.0 (2024-12-10)

--- a/yml2block/datatypes.py
+++ b/yml2block/datatypes.py
@@ -74,3 +74,6 @@ class MDBlockNode:
 
     def __repr__(self):
         return f"({self.line}, {self.column}) {self.value}"
+
+    def __str__(self):
+        return f"'{self.value}' (l:{self.line},c:{self.column})"

--- a/yml2block/rules.py
+++ b/yml2block/rules.py
@@ -449,7 +449,7 @@ def no_trailing_spaces(list_item, tsv_keyword, level=Level.WARNING):
                 LintViolation(
                     level,
                     "no_trailing_spaces",
-                    f"The entry '{value}' has one or more trailing spaces.",
+                    f"The entry {value} has one or more trailing spaces.",
                     list_item[entry].line,
                     list_item[entry].column,
                 )
@@ -480,7 +480,7 @@ def nested_compound_metadata(list_item, tsv_keyword, level=Level.WARNING):
             LintViolation(
                 level,
                 "nested_compound_metadata",
-                f"The entry '{list_item["name"]}' allows multiple entries in a nested field.",
+                f"The entry {list_item["name"]} allows multiple entries in a nested field.",
                 list_item["allowmultiples"].line,
                 list_item["allowmultiples"].column,
             )
@@ -514,7 +514,7 @@ def nested_compound_metadata_controlled_vocab(
             LintViolation(
                 level,
                 "nested_compound_metadata_controlled_vocab",
-                f"The entry '{list_item["name"]}' allows multiple entries in a nested field.",
+                f"The entry {list_item["name"]} allows multiple entries in a nested field.",
                 list_item["allowmultiples"].line,
                 list_item["allowmultiples"].column,
             )

--- a/yml2block/yaml_input.py
+++ b/yml2block/yaml_input.py
@@ -16,7 +16,10 @@ def to_md_block_types(data, parent=None, parent_key=None):
     match data:
         case dict():
             return MDBlockDict(
-                {key: to_md_block_types(val, parent=data, parent_key=key) for key, val in data.items()},
+                {
+                    key: to_md_block_types(val, parent=data, parent_key=key)
+                    for key, val in data.items()
+                },
                 line=data.lc.line,
                 column=data.lc.col,
             )
@@ -38,6 +41,7 @@ def to_md_block_types(data, parent=None, parent_key=None):
                 )
             else:
                 return MDBlockNode(data)
+
 
 def read_yaml(file_path, lint_conf, verbose):
     """Read in a yaml file and convert it into a python dictionary structure."""

--- a/yml2block/yaml_input.py
+++ b/yml2block/yaml_input.py
@@ -8,7 +8,7 @@ from yml2block.datatypes import MDBlockList, MDBlockDict, MDBlockNode
 from yml2block import validation
 
 
-def to_md_block_types(data):
+def to_md_block_types(data, parent=None, parent_key=None):
     """This function takes a ruamel YAML structure and wraps its
     content into custom types that support annotation with line and column
     numbers to be compatible with the tsv input.
@@ -16,7 +16,7 @@ def to_md_block_types(data):
     match data:
         case dict():
             return MDBlockDict(
-                {key: to_md_block_types(val) for key, val in data.items()},
+                {key: to_md_block_types(val, parent=data, parent_key=key) for key, val in data.items()},
                 line=data.lc.line,
                 column=data.lc.col,
             )
@@ -27,8 +27,17 @@ def to_md_block_types(data):
                 column=data.lc.col,
             )
         case _:
-            return MDBlockNode(data)
-
+            # Non-collection entries do not have the lc attribute but can
+            # get their line and column numbers from the lc object of their
+            # parent collection.
+            if parent and parent_key:
+                return MDBlockNode(
+                    data,
+                    line=parent.lc.key(parent_key)[0],
+                    column=parent.lc.key(parent_key)[1],
+                )
+            else:
+                return MDBlockNode(data)
 
 def read_yaml(file_path, lint_conf, verbose):
     """Read in a yaml file and convert it into a python dictionary structure."""


### PR DESCRIPTION
This PR improves how line and column numbers are handled in yaml input. Line and column numbers can now be reported for the keys of the lowest level dictionaries in the input files. 