### PR TITLE
fix(output): preserve explicit empty string fields during TSV conversion

### DIFF
--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -212,3 +212,31 @@ def test_error_flag():
         ["check", "--error", "e004", "tests/invalid/whitespace_in_key.yml"],
     )
     assert result.exit_code == 1, result.output
+
+
+def test_convert_preserves_explicit_empty_string_fields():
+    """Ensure quoted empty strings do not shift TSV columns during conversion."""
+    runner = CliRunner()
+    input_file = "tests/valid/explicit_empty_string_watermark.yml"
+    output_file = "/tmp/y2b_explicit_empty_string_watermark.tsv"
+    result = runner.invoke(
+        yml2block.__main__.main,
+        ["convert", input_file, "-o", output_file],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Invalid entry ''" not in result.output
+
+    with open(output_file, "r") as tsv_file:
+        lines = tsv_file.readlines()
+
+    header_idx = next(
+        idx for idx, line in enumerate(lines) if line.startswith("#datasetField")
+    )
+    header = lines[header_idx].rstrip("\n").split("\t")
+    row = lines[header_idx + 1].rstrip("\n").split("\t")
+
+    assert len(header) == len(row)
+    assert row[header.index("watermark")] == ""
+    assert row[header.index("fieldType")] == "text"
+    assert row[header.index("displayOrder")] == "1"

--- a/tests/valid/explicit_empty_string_watermark.yml
+++ b/tests/valid/explicit_empty_string_watermark.yml
@@ -1,0 +1,20 @@
+metadataBlock:
+  - name: Example
+    dataverseAlias:
+    displayName: Example
+datasetField:
+  - name: Foo
+    title: Foo
+    description: Some field
+    watermark: ""
+    fieldType: text
+    displayOrder: 1
+    displayFormat:
+    advancedSearchField: true
+    allowControlledVocabulary: false
+    allowmultiples: false
+    facetable: false
+    displayoncreate: true
+    required: true
+    parent:
+    metadatablock_id: Example

--- a/yml2block/__main__.py
+++ b/yml2block/__main__.py
@@ -3,6 +3,7 @@
 
 https://guides.dataverse.org/en/latest/admin/metadatacustomization.html
 """
+
 import os
 import sys
 import click

--- a/yml2block/output.py
+++ b/yml2block/output.py
@@ -36,6 +36,10 @@ def write_metadata_block(yml_metadata, output_path, longest_line, verbose):
                         # This catches empty values, which yaml reports
                         # as a Python None
                         new_line.append("")
+                    elif value == "":
+                        # Quoted empty strings in YAML are valid values and
+                        # must produce an empty TSV cell without shifting columns.
+                        new_line.append("")
                     elif str(value):
                         # This could be more specific using int() and float()
                         # The conversion of `value` to a string happens to


### PR DESCRIPTION
## Summary
This PR fixes #29  a TSV conversion bug where explicit empty strings in YAML (for example `watermark: ""`) were treated as invalid entries.

Before this change, `convert` printed `Invalid entry ''` and could shift subsequent fields in affected TSV rows.

## Root Cause
In `yml2block/output.py`, explicit empty strings (`""`) were not handled as valid values.
They fell through to the error branch instead of being written as an empty TSV cell.

## Changes
- **Fix:** Treat `value == ""` as a valid empty output cell during TSV writing.
- **Test:** Added regression coverage for this behavior in integration tests.
- **Fixture:** Added `tests/valid/explicit_empty_string_watermark.yml` to match existing test data conventions.

## Files Changed
- `yml2block/output.py`
- `tests/integration_tests.py`
- `tests/valid/explicit_empty_string_watermark.yml`

## Verification
Ran:
```bash
poetry run pytest -q tests/unit_tests.py tests/integration_tests.py
```

Result:

- 19 passed

Additionally re-ran conversion on the reported real-world input:

- No more `Invalid entry ''` messages
- No column shifts in the previously affected rows