### PR TITLE
Improve TSV breakpoint suggestionsImprove TSV breakpoint suggestions

### DIFF
--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -132,6 +132,34 @@ def test_wrong_extensions_fail():
     assert result.exit_code == 1, result.output
 
 
+def test_tsv_breakpoint_suggestions_are_reported():
+    """Ensure malformed TSV block headers produce actionable suggestions."""
+    runner = CliRunner()
+    test_cases = [
+        (
+            "tests/invalid/no_block_headers.tsv",
+            "No block headers were found",
+        ),
+        (
+            "tests/invalid/one_block_header.tsv",
+            "Only one block header was found",
+        ),
+        (
+            "tests/invalid/too_many_block_headers.tsv",
+            "Expected 2 or 3 block headers but found 4",
+        ),
+    ]
+
+    for input_file, expected_message in test_cases:
+        result = runner.invoke(
+            yml2block.__main__.main,
+            ["check", "--warn-ec", "2", input_file],
+        )
+        assert result.exit_code != 0, result.output
+        assert "identify_break_points" in result.output
+        assert expected_message in result.output
+
+
 def test_nested_compound_metadata():
     """Ensure nested compound metadata are detected and classified correctly."""
 

--- a/tests/invalid/no_block_headers.tsv
+++ b/tests/invalid/no_block_headers.tsv
@@ -1,0 +1,2 @@
+name	displayName
+ValidExample	Valid

--- a/tests/invalid/one_block_header.tsv
+++ b/tests/invalid/one_block_header.tsv
@@ -1,0 +1,2 @@
+#metadataBlock
+	ValidExample

--- a/tests/invalid/too_many_block_headers.tsv
+++ b/tests/invalid/too_many_block_headers.tsv
@@ -1,0 +1,4 @@
+#metadataBlock
+#datasetField
+#controlledVocabulary
+#extraBlock

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -157,6 +157,7 @@ def test_breakpoint_identification():
                 {
                     "level": Level.WARNING,
                     "rule": "identify_break_points",
+                    "message_contains": "Only one block header was found",
                 }
             ],
         },
@@ -167,6 +168,7 @@ def test_breakpoint_identification():
                 {
                     "level": Level.WARNING,
                     "rule": "identify_break_points",
+                    "message_contains": "Expected 2 or 3 block headers but found 4",
                 }
             ],
         },
@@ -185,3 +187,4 @@ def test_breakpoint_identification():
         for vio, exp_vio in zip(violations, test_case["expected_violations"]):
             assert vio.level == exp_vio["level"]
             assert vio.rule == exp_vio["rule"]
+            assert exp_vio["message_contains"] in vio.message

--- a/yml2block/suggestions.py
+++ b/yml2block/suggestions.py
@@ -62,20 +62,45 @@ def fix_required_keys_present(missing_keys, list_item, tsv_keyword):
 
 def fix_identify_breaking_points(full_file, break_points):
     """Suggest fixes for too little or too many detected blocks."""
+    lines = full_file.splitlines() if isinstance(full_file, str) else full_file
+
+    def _line_index(break_point):
+        if isinstance(full_file, str):
+            return full_file.count("\n", 0, break_point)
+        return break_point
+
     match len(break_points):
         case 0:
-            # No line starts with #
-            # are you passing the right file?
-            ...
+            return (
+                "Unable to split TSV file into blocks. No block headers were found. "
+                "Make sure this is a Dataverse TSV metadata block file and that it "
+                "contains lines starting with '#metadataBlock' and '#datasetField' "
+                "(plus optional '#controlledVocabulary')."
+            )
         case 1:
-            # Only one line starts with #
-            # At least two blocks are required for a reasonable metadata schema
-            ...
+            header_index = _line_index(break_points[0])
+            line_no = header_index + 1
+            header = lines[header_index].strip()
+            return (
+                "Unable to split TSV file into blocks. Only one block header was "
+                f"found at line {line_no}: '{header}'. A valid TSV metadata block "
+                "needs at least '#metadataBlock' and '#datasetField' headers."
+            )
         case 2 | 3:
             # This case should never be reached, those files are fine
             # Raise an exception if I get here in error handling
-            ...
+            raise ValueError(
+                "Breakpoint suggestions are only needed for invalid TSV block counts."
+            )
         case _:
-            # More than the required number of blocks is present.
-            # Identify what is going on.
-            ...
+            extra_headers = [
+                f"line {header_index + 1}: '{lines[header_index].strip()}'"
+                for header_index in (_line_index(bp) for bp in break_points[3:])
+            ]
+            return (
+                "Unable to split TSV file into blocks. Expected 2 or 3 block headers "
+                f"but found {len(break_points)}. Extra header candidates: "
+                f"{', '.join(extra_headers)}. Remove stray lines starting with '#' "
+                "or keep only '#metadataBlock', '#datasetField', and optional "
+                "'#controlledVocabulary' as block headers."
+            )

--- a/yml2block/tsv_input.py
+++ b/yml2block/tsv_input.py
@@ -8,6 +8,7 @@ import itertools
 
 from yml2block.rules import LintViolation, Level
 from yml2block.datatypes import MDBlockList, MDBlockDict, MDBlockNode
+from yml2block import suggestions
 
 
 def _identify_break_points(full_file):
@@ -29,13 +30,12 @@ def _identify_break_points(full_file):
             None,
         )
     else:
-        # TODO: suggest better fix for this
         split_blocks = full_file
         violations.append(
             LintViolation(
                 Level.WARNING,
                 "identify_break_points",
-                "Unable to split TSV file into blocks. Check tsv file formatting.",
+                suggestions.fix_identify_breaking_points(full_file, break_points),
             )
         )
     return split_blocks, violations

--- a/yml2block/tsv_input.py
+++ b/yml2block/tsv_input.py
@@ -52,6 +52,8 @@ def read_tsv(tsv_path):
     # Split metadata schema into blocks
     split_blocks, break_point_violations = _identify_break_points(full_file)
     violations.extend(break_point_violations)
+    if break_point_violations:
+        return data, violations
 
     def _parse(block):
         """Parse a CSV block into a dictionary."""


### PR DESCRIPTION
## Summary
- Add actionable suggestions for invalid TSV breakpoint detection.
- Explain when no block headers, only one block header, or too many block headers are found.
- Reuse the existing `suggestions.py` helper from TSV input parsing.
- Add unit assertions for the new suggestion messages.

## Validation
- `PYTHONPATH=. pytest tests/unit_tests.py tests/integration_tests.py -q`
- `black --check --verbose yml2block/`

Addresses #35.